### PR TITLE
Bare-close think-trace hardening (live-daemon verified) + real README transcript + brew tap

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,13 @@ bootstraps [Ollama](https://ollama.com) with `qwen3:4b` if you don't have it.
 + ~2.5 GB of model weights. Budget 5–15 minutes on a decent connection. You
 need roughly 4 GB of free RAM to run `qwen3:4b` comfortably.
 
+On macOS you can also install through the tap:
+
+```bash
+brew tap mkbhardwas12/prismos
+brew install --cask prismos-ai   # add --no-quarantine to skip the Gatekeeper dance
+```
+
 Prefer to click? Grab an installer from the
 [Releases page](https://github.com/mkbhardwas12/prismos-ai/releases/latest):
 
@@ -127,9 +134,29 @@ cat notes.md | ./target/release/prismos-cli ask --stdin --model qwen3:4b
 `PRISMOS_MODEL` and `PRISMOS_OLLAMA_URL` override the defaults. It's pipeable,
 so it composes with the rest of your shell.
 
-<!-- TODO(manish): paste one real transcript here — the exact question, the
-     model, the wall-clock time, and the verbatim answer. A single real
-     example is worth more than every feature row below it. -->
+Here's a real run — unedited, `qwen3:4b` (Q4_K_M, 2.5 GB) on an M5 Max, 64 GB:
+
+```console
+$ prismos-cli ask "explain WASM sandboxing in one paragraph"
+WebAssembly (WASM) modules themselves do not include built-in sandboxing;
+instead, **browsers enforce strict security policies that isolate WASM
+execution within a secure sandbox** to prevent malicious behavior. This
+sandbox restricts WASM from directly accessing the DOM, file system, network
+resources, or other system-level features, enforces memory isolation via
+linear memory with strict access controls (preventing memory corruption or
+unauthorized reads/writes), and requires code signing to verify module
+integrity before execution. By design, browsers treat WASM as a confined,
+trusted environment that minimizes attack surfaces while enabling
+high-performance web applications without compromising security—effectively
+acting as a critical layer of defense against exploits like cross-site
+scripting (XSS) or resource theft when WASM code is deployed in the browser
+context.
+```
+
+8.4 s wall-clock (including the model's hidden reasoning pass), 134 tokens/s.
+And an honesty note: the answer has a small-model wobble — WASM does *not*
+require code signing. That's what a 2.5 GB model really sounds like; bigger
+local models sharpen it, and nothing leaves the machine either way.
 
 ---
 

--- a/src-tauri/src/bin/prismos_cli.rs
+++ b/src-tauri/src/bin/prismos_cli.rs
@@ -389,6 +389,14 @@ fn partial_suffix_len(s: &str, tag: &str) -> usize {
 
 /// Strip inline <think>…</think> blocks (older daemons leak them into the text).
 fn strip_think(s: &str) -> String {
+    // Bare `</think>` with no opening tag (old daemon/template combos with
+    // think:false — the template pre-fills the open tag): everything before
+    // the close is trace.
+    if !s.contains("<think>") {
+        if let Some(close) = s.find("</think>") {
+            return s[close + 8..].trim_start().to_string();
+        }
+    }
     let (mut out, mut rest) = (String::with_capacity(s.len()), s);
     loop {
         match rest.find("<think>") {

--- a/src-tauri/src/ollama_bridge.rs
+++ b/src-tauri/src/ollama_bridge.rs
@@ -108,6 +108,16 @@ fn output_tokens_for(will_think: bool) -> u32 {
 // Older daemons (or model tags that reject the flag) return 4xx — the request
 // layer retries once without `think`, so behavior degrades gracefully instead
 // of erroring.
+//
+// Empirically verified against a live daemon (Ollama 0.24.0, qwen3:4b blob
+// pulled 2026-05): `think:false` is ACCEPTED (200) but ignored by the old
+// template — worse, sending it disables Ollama's trace separation, so the
+// trace lands raw in `response`/`content` with a bare `</think>` close tag
+// and NO opening tag (the template pre-fills `<think>`). Omitting the field
+// keeps separation working but pays full trace latency everywhere. We keep
+// sending `think:false` (correct + fast on current daemons/blobs) and harden
+// the strippers below to catch the bare-close artifact on old combos.
+// Upgrading Ollama / re-pulling the model restores real suppression.
 
 /// Hybrid models whose thinking should default OFF for everyday answers.
 /// qwen3-coder (and any *-coder tag) is a non-thinking family — excluded.
@@ -178,6 +188,12 @@ const THINK_CLOSE: &str = "</think>";
 /// An unclosed `<think>` (stream cut mid-thought) drops the dangling block.
 fn strip_think_blocks(s: &str) -> String {
     if !s.contains(THINK_OPEN) {
+        // Bare `</think>` with no opening tag (see the Thinking control notes:
+        // old template + `think:false` pre-fills the open tag) — everything
+        // before the close is trace.
+        if let Some(close) = s.find(THINK_CLOSE) {
+            return s[close + THINK_CLOSE.len()..].trim_start().to_string();
+        }
         return s.to_string();
     }
     let mut out = String::with_capacity(s.len());
@@ -797,7 +813,11 @@ where
                     on_token(StreamEvent { token: tail, done: false, truncated: false });
                 }
                 on_token(StreamEvent { token: String::new(), done: true, truncated });
-                return Ok(full_response);
+                // The live filter can't retroactively unsee a bare-`</think>`
+                // leak (no opening tag → tokens already emitted); the returned
+                // value is stripped again so persisted/agent-facing text is
+                // clean regardless of daemon quirks.
+                return Ok(strip_think_blocks(&full_response));
             }
         }
     }
@@ -809,7 +829,7 @@ where
         on_token(StreamEvent { token: tail, done: false, truncated: false });
     }
     on_token(StreamEvent { token: String::new(), done: true, truncated });
-    Ok(full_response)
+    Ok(strip_think_blocks(&full_response))
 }
 
 // ─── Tests ─────────────────────────────────────────────────────────────────────
@@ -952,6 +972,15 @@ mod tests {
             strip_think_blocks("<think>a</think>x<think>b</think>y"),
             "xy"
         );
+        // Bare close tag, no opening (Ollama 0.24 + old qwen3 blob with
+        // think:false — template pre-fills <think>, model emits only the
+        // close): everything before it is trace.
+        assert_eq!(
+            strip_think_blocks("Okay, the user wants...</think>\n\nThe answer."),
+            "The answer."
+        );
+        // A close tag with no trace before it — degenerate but clean.
+        assert_eq!(strip_think_blocks("</think>hi"), "hi");
     }
 
     #[test]


### PR DESCRIPTION
Ships the two changes that were stranded on a local branch, rebuilt byte-identically and verified standalone (14/14 bridge tests).

**Hardening (empirically verified against a live Ollama 0.24.0 + May-2026 qwen3:4b blob):** `think:false` is accepted but ignored by the old template on BOTH endpoints — and sending it disables trace separation, so the reasoning lands in the answer with a bare `</think>` and no opening tag. strip_think_blocks + the CLI strip now handle that shape; generate_stream returns a re-stripped value so persisted/agent text is clean even when the live stream leaked. Notes in the Thinking-control section document the matrix; upgrading Ollama / re-pulling restores real suppression.

**README:** real CLI transcript from an M5 Max (qwen3:4b, 8.4s, 134 tok/s, small-model wobble flagged honestly) + Homebrew tap install (mkbhardwas12/homebrew-prismos, per-arch SHA256s).

Note for the local checkout: commits 04fa8d1/c219f69 on the local fix/honest-positioning branch are the same content — after this merges, drop them (`git checkout main && git pull`; discard the stale branch) rather than pushing that branch.