### PR TITLE
Make qwen3.5:27b the app default on 64GB-class machines

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ local models sharpen it, and nothing leaves the machine either way.
 
 | | |
 |---|---|
-| **Ask a local model** | Streaming chat against any Ollama model, with a curated registry of 15 models and hardware-aware recommendations on first run. |
+| **Ask a local model** | Streaming chat against any Ollama model, with a curated registry of 17 models and hardware-aware recommendations on first run. |
 | **Drop in documents** | PDF, DOCX, PPTX, XLSX. Text is extracted on-device, chunked, and retrieved with TF-IDF instead of naively truncated. |
 | **Remember across sessions** | Answers and the concepts in them persist to a local SQLite knowledge graph you can browse, search, and view as a timeline. |
 | **Route to the right model** | Attach an image and it swaps to a vision model, then swaps back. Same for code-heavy prompts. |

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -8,10 +8,12 @@
 export const DEFAULT_OLLAMA_URL = "http://localhost:11434";
 
 /** Default AI model to use if none is configured in settings.
- *  qwen3:30b-a3b is an MoE model (~3B active params/token) — Claude-class quality
- *  for everyday use while staying fast on Apple-silicon unified memory. The smart
- *  router auto-swaps to a code/vision/reasoning specialist per task when relevant. */
-export const DEFAULT_MODEL = "qwen3:30b-a3b";
+ *  qwen3.5:27b is the newest-generation dense flagship — strong text, code and
+ *  reasoning at ~20 tok/s fully offline on 64GB-class unified memory, and its
+ *  current template cleanly honours the `think:false` flag (no trace tax).
+ *  resolveDefaultModel falls back gracefully on machines that don't have it
+ *  pulled; the smart router still swaps to specialists per task. */
+export const DEFAULT_MODEL = "qwen3.5:27b";
 
 /** True if a saved model name refers to the same model as an installed one,
  *  tolerating the implicit `:latest` tag (Ollama lists `llama3.2:latest` but a

--- a/src/lib/modelRegistry.ts
+++ b/src/lib/modelRegistry.ts
@@ -27,11 +27,28 @@ export type ModelCapability =
   | "long-context";
 
 export const MODEL_REGISTRY: ModelSpec[] = [
+  // ══════════ FLAGSHIP DEFAULT (64GB-class machines) ══════════
+  {
+    name: "qwen3.5:27b",
+    label: "Qwen 3.5 27B",
+    desc: "🏆 Default on 64GB-class machines — newest-gen dense flagship, ~20 tok/s fully offline",
+    size: "~17 GB",
+    vramMin: 0,
+    ramMin: 32,
+    context: 262144,
+    tier: "power",
+    capabilities: ["text", "code", "reasoning", "multilingual", "math", "long-context"],
+    license: "Apache-2.0",
+    isDefault: true,
+    priority: 1,
+    releaseYear: 2026,
+  },
+
   // ══════════ ESSENTIAL (Tier 1 — works on most machines) ══════════
   {
     name: "qwen3:4b",
     label: "Qwen 3 4B",
-    desc: "🏆 New Default — better than Llama 3.2 at same size, 128K context",
+    desc: "Compact all-rounder — better than Llama 3.2 at same size, 128K context",
     size: "~2.5 GB",
     vramMin: 0,
     ramMin: 4,
@@ -39,7 +56,6 @@ export const MODEL_REGISTRY: ModelSpec[] = [
     tier: "essential",
     capabilities: ["text", "multilingual", "agentic"],
     license: "Apache-2.0",
-    isDefault: true,
     priority: 1,
     releaseYear: 2025,
   },
@@ -189,6 +205,20 @@ export const MODEL_REGISTRY: ModelSpec[] = [
   },
 
   // ══════════ POWER USER (24GB+ VRAM) ══════════
+  {
+    name: "qwen3:30b-a3b",
+    label: "Qwen 3 30B-A3B",
+    desc: "MoE — 30.5B total, ~3B active: near-flagship quality at small-model speed",
+    size: "~19 GB",
+    vramMin: 0,
+    ramMin: 32,
+    context: 262144,
+    tier: "power",
+    capabilities: ["text", "code", "reasoning", "multilingual", "agentic"],
+    license: "Apache-2.0",
+    priority: 29,
+    releaseYear: 2025,
+  },
   {
     name: "qwen3:32b",
     label: "Qwen 3 32B",

--- a/src/test/config.test.ts
+++ b/src/test/config.test.ts
@@ -25,7 +25,7 @@ describe("modelMatches", () => {
 });
 
 describe("resolveDefaultModel", () => {
-  const installed = ["qwen3:30b-a3b", "qwen2.5-coder:7b", "llama3.1:8b"];
+  const installed = ["qwen3.5:27b", "qwen3:30b-a3b", "qwen2.5-coder:7b", "llama3.1:8b"];
 
   it("keeps the saved model when it is installed (no fallback)", () => {
     const r = resolveDefaultModel("qwen2.5-coder:7b", installed);
@@ -36,7 +36,7 @@ describe("resolveDefaultModel", () => {
     // The exact bug: a saved deepseek-v3:16b that was never pulled.
     const r = resolveDefaultModel("deepseek-v3:16b", installed);
     expect(r.fellBack).toBe(true);
-    expect(r.model).toBe(DEFAULT_MODEL); // qwen3:30b-a3b is installed
+    expect(r.model).toBe(DEFAULT_MODEL); // qwen3.5:27b is installed
   });
 
   it("falls back to the first installed model when DEFAULT_MODEL is also absent", () => {


### PR DESCRIPTION
## Description

Ports the intent of stranded commit `01a1e1d` (never-merged `feat/loop-engine-prep`) onto main's current registry schema. Manish pulled `qwen3.5:27b` on Aug 5 and wired it as default on that branch, but main never got it — main's `DEFAULT_MODEL` (`qwen3:30b-a3b`) wasn't even in the registry, and the registry's `isDefault` pointed at `qwen3:4b`. This makes the three sources of truth agree.

- **modelRegistry.ts** — add `qwen3.5:27b` as the flagship default (`isDefault: true`, priority 1, 256K ctx, `vramMin: 0` so Apple unified memory qualifies); add the previously-missing `qwen3:30b-a3b` to the POWER tier; demote `qwen3:4b` to a regular essential entry. Registry goes 15 → 17 models.
- **config.ts** — `DEFAULT_MODEL = "qwen3.5:27b"`. `resolveDefaultModel` still self-heals on machines that don't have it pulled.
- **config.test.ts** — installed-models fixture updated for the new default.
- **README.md** — "curated registry of 15 models" → 17.

## Why qwen3.5:27b

Verified live against the local daemon (Ollama 0.24.0): the Aug-5 `qwen3.5:27b` blob honours `think: false` cleanly — 8-token direct answer, no reasoning trace, no bare `</think>` leakage — so the think-control path from #9/#15 works at full effectiveness on it.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## Checks

- `npx vitest run` — 176/176 green with these exact file contents
- `npx tsc --noEmit` — clean
- All four files byte-verified against the gated copies after commit.