### PR TITLE
Add Qwen3.8-27B (released today) to the model registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ local models sharpen it, and nothing leaves the machine either way.
 
 | | |
 |---|---|
-| **Ask a local model** | Streaming chat against any Ollama model, with a curated registry of 17 models and hardware-aware recommendations on first run. |
+| **Ask a local model** | Streaming chat against any Ollama model, with a curated registry of 18 models and hardware-aware recommendations on first run. |
 | **Drop in documents** | PDF, DOCX, PPTX, XLSX. Text is extracted on-device, chunked, and retrieved with TF-IDF instead of naively truncated. |
 | **Remember across sessions** | Answers and the concepts in them persist to a local SQLite knowledge graph you can browse, search, and view as a timeline. |
 | **Route to the right model** | Attach an image and it swaps to a vision model, then swaps back. Same for code-heavy prompts. |

--- a/src/lib/modelRegistry.ts
+++ b/src/lib/modelRegistry.ts
@@ -44,6 +44,21 @@ export const MODEL_REGISTRY: ModelSpec[] = [
     releaseYear: 2026,
   },
 
+  {
+    name: "qwen3.8:27b",
+    label: "Qwen 3.8 27B",
+    desc: "Newest-gen dense flagship (Aug 2026) — 256K context; needs the latest Ollama",
+    size: "~18 GB",
+    vramMin: 0,
+    ramMin: 32,
+    context: 262144,
+    tier: "power",
+    capabilities: ["text", "code", "reasoning", "multilingual", "math", "long-context"],
+    license: "Apache-2.0",
+    priority: 1,
+    releaseYear: 2026,
+  },
+
   // ══════════ ESSENTIAL (Tier 1 — works on most machines) ══════════
   {
     name: "qwen3:4b",


### PR DESCRIPTION
## Description

Qwen3.8-27B landed on the Ollama library today (Aug 14) — tags went live minutes before this PR. This adds it to the curated registry so it shows up in the picker with correct hardware guidance.

- **modelRegistry.ts** — add `qwen3.8:27b` (power tier, priority 1, ~18 GB, 256K ctx, Apache-2.0, `vramMin: 0` so Apple unified memory qualifies). `qwen3.5:27b` stays the default for now. Registry 17 → 18.
- **README.md** — model count 17 → 18.

**Why not the default yet:** pulling `qwen3.8:27b` requires a newer Ollama than 0.24 (registry answers `412`), so the `think:false` behaviour of its brand-new template can't be live-verified until the daemon is upgraded. Once verified clean, a follow-up PR flips `isDefault`/`DEFAULT_MODEL` (change is staged and gated).

Note: the ollama_bridge think-control already treats the whole qwen3 dense family as hybrid-thinking, so `qwen3.8:*` gets `think:false` + bare-close hardening with no code change.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## Checks

- `npx vitest run` — 176/176 green with these exact contents
- `npx tsc --noEmit` — clean
- modelRegistry.ts byte-verified against the gated copy after commit; README verified via blob view (raw CDN was stale).