### PR TITLE
Make qwen3.8:27b the default — live-probed clean on Ollama 0.32.12

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -858,6 +858,17 @@ async fn pull_ollama_model(app: tauri::AppHandle, model: String, ollama_url: Opt
     }
 
     if let Some(err) = stream_error {
+        // A 412 from the registry means the local Ollama is too old for this
+        // model's manifest — the tag is fine, the daemon needs an update. Say
+        // that instead of sending the user off to double-check the model name.
+        if err.contains("412") || err.contains("newer version of Ollama") {
+            return Err(format!(
+                "Couldn't pull '{}': your Ollama is too old for this model. \
+                 Update Ollama (brew upgrade ollama, or ollama.com/download), \
+                 then pull again.",
+                model
+            ));
+        }
         return Err(format!(
             "Couldn't pull '{}': {}. Check the model name/tag exists on ollama.com \
              (e.g. DeepSeek reasoning is `deepseek-r1:32b`, not `deepseek-v3:16b`).",

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -8,12 +8,12 @@
 export const DEFAULT_OLLAMA_URL = "http://localhost:11434";
 
 /** Default AI model to use if none is configured in settings.
- *  qwen3.5:27b is the newest-generation dense flagship — strong text, code and
- *  reasoning at ~20 tok/s fully offline on 64GB-class unified memory, and its
- *  current template cleanly honours the `think:false` flag (no trace tax).
- *  resolveDefaultModel falls back gracefully on machines that don't have it
- *  pulled; the smart router still swaps to specialists per task. */
-export const DEFAULT_MODEL = "qwen3.5:27b";
+ *  qwen3.8:27b (Aug 2026) is the newest-generation dense flagship — 256K
+ *  context, strong text/code/reasoning on 64GB-class unified memory. Requires
+ *  a current Ollama build; resolveDefaultModel falls back gracefully (e.g. to
+ *  an installed qwen3.5:27b) on machines that don't have it pulled, and the
+ *  smart router still swaps to specialists per task. */
+export const DEFAULT_MODEL = "qwen3.8:27b";
 
 /** True if a saved model name refers to the same model as an installed one,
  *  tolerating the implicit `:latest` tag (Ollama lists `llama3.2:latest` but a

--- a/src/lib/modelRegistry.ts
+++ b/src/lib/modelRegistry.ts
@@ -29,10 +29,10 @@ export type ModelCapability =
 export const MODEL_REGISTRY: ModelSpec[] = [
   // ══════════ FLAGSHIP DEFAULT (64GB-class machines) ══════════
   {
-    name: "qwen3.5:27b",
-    label: "Qwen 3.5 27B",
-    desc: "🏆 Default on 64GB-class machines — newest-gen dense flagship, ~20 tok/s fully offline",
-    size: "~17 GB",
+    name: "qwen3.8:27b",
+    label: "Qwen 3.8 27B",
+    desc: "🏆 Default on 64GB-class machines — newest-gen dense flagship, 256K context (needs latest Ollama)",
+    size: "~18 GB",
     vramMin: 0,
     ramMin: 32,
     context: 262144,
@@ -45,10 +45,10 @@ export const MODEL_REGISTRY: ModelSpec[] = [
   },
 
   {
-    name: "qwen3.8:27b",
-    label: "Qwen 3.8 27B",
-    desc: "Newest-gen dense flagship (Aug 2026) — 256K context; needs the latest Ollama",
-    size: "~18 GB",
+    name: "qwen3.5:27b",
+    label: "Qwen 3.5 27B",
+    desc: "Previous-gen dense flagship — ~20 tok/s fully offline, cleanly honours think:false",
+    size: "~17 GB",
     vramMin: 0,
     ramMin: 32,
     context: 262144,

--- a/src/test/config.test.ts
+++ b/src/test/config.test.ts
@@ -25,7 +25,7 @@ describe("modelMatches", () => {
 });
 
 describe("resolveDefaultModel", () => {
-  const installed = ["qwen3.5:27b", "qwen3:30b-a3b", "qwen2.5-coder:7b", "llama3.1:8b"];
+  const installed = ["qwen3.8:27b", "qwen3.5:27b", "qwen3:30b-a3b", "qwen2.5-coder:7b", "llama3.1:8b"];
 
   it("keeps the saved model when it is installed (no fallback)", () => {
     const r = resolveDefaultModel("qwen2.5-coder:7b", installed);
@@ -36,7 +36,7 @@ describe("resolveDefaultModel", () => {
     // The exact bug: a saved deepseek-v3:16b that was never pulled.
     const r = resolveDefaultModel("deepseek-v3:16b", installed);
     expect(r.fellBack).toBe(true);
-    expect(r.model).toBe(DEFAULT_MODEL); // qwen3.5:27b is installed
+    expect(r.model).toBe(DEFAULT_MODEL); // qwen3.8:27b is installed
   });
 
   it("falls back to the first installed model when DEFAULT_MODEL is also absent", () => {


### PR DESCRIPTION
## Description

Qwen3.8-27B is now installed and verified on the reference 64GB machine, so this flips the default that #17 deliberately deferred.

**Live verification (Ollama 0.32.12, local daemon, Aug 14):**
- `think:false` → direct 53-token answer, no reasoning trace, no `<think>`/bare `</think>` leakage, `done_reason: stop`, **36.2 tok/s** (vs ~14.8 for qwen3.5:27b on the same box)
- default (thinking on) → `thinking` field cleanly separated from `response`, no tag leakage

**Changes:**
- **modelRegistry.ts** — `qwen3.8:27b` takes `isDefault` and the top slot; `qwen3.5:27b` stays as previous-gen fallback (both priority 1).
- **config.ts** — `DEFAULT_MODEL = "qwen3.8:27b"`; comment documents graceful fallback for machines without it.
- **config.test.ts** — fixture gains qwen3.8:27b; fallback-comment updated.
- **lib.rs** — pull errors that are really *"your Ollama is too old"* (HTTP 412) now say exactly that instead of the misleading "check the model name/tag" hint. This exact confusion happened in the field today.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## Checks

- `npx vitest run` — 176/176 green with these exact file contents
- `npx tsc --noEmit` — clean
- Rust change gated by CI's Backend job (container lacks GTK for local cargo check)