### PR TITLE
Fix doc/PPT generation: token starvation, no context, unrepaired truncation

### DIFF
--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -299,10 +299,18 @@ export function useChat({
             throw new Error("Ollama is not running. Please start Ollama first: ollama serve");
           }
 
+          // Recent conversation, so "create a doc on this" knows what "this" is.
+          const recentContext = messages
+            .slice(-4)
+            .map((m) => `${m.role === "user" ? "User" : "Assistant"}: ${m.content}`)
+            .join("\n")
+            .slice(-1600);
+
           const attachment = await generateDocument(docKind, input, {
             model: settings.defaultModel || "mistral",
             ollamaUrl: settings.ollamaUrl || null,
             maxTokens: settings.maxTokens || 4096,
+            context: recentContext || undefined,
             onPhase: setProcessingPhase,
           });
 

--- a/src/lib/docGen.ts
+++ b/src/lib/docGen.ts
@@ -9,6 +9,11 @@ import type { GeneratedAttachment } from "../types";
 
 export type DocKind = "docx" | "pptx";
 
+/** Doc specs need room for full paragraphs (and reasoning-model traces count
+ *  against the same budget) — never let the chat response-length slider starve
+ *  them. */
+const MIN_SPEC_TOKENS = 8192;
+
 /**
  * Detect whether the user is asking to CREATE a Word document or PowerPoint.
  * Requires a creation verb plus a document/presentation noun to avoid firing
@@ -23,11 +28,11 @@ export function detectDocRequest(input: string): DocKind | null {
   if (!createVerb) return null;
 
   const pptWords =
-    /\b(power\s?point|pptx|presentation|slide\s?deck|slides?|slideshow|deck)\b/.test(
+    /\b(power\s?point|pptx?|presentation|slide\s?deck|slides?|slideshow|deck)\b/.test(
       t,
     );
   const docWords =
-    /\b(word\s+document|word\s+doc|docx|word\s+file|\bdocument\b|report|write-?up|essay|letter|memo|brief)\b/.test(
+    /\b(word\s+document|word\s+doc|docx?|word\s+file|\bdocument\b|report|write-?up|essay|letter|memo|brief)\b/.test(
       t,
     );
 
@@ -37,11 +42,19 @@ export function detectDocRequest(input: string): DocKind | null {
 }
 
 /** Build the system-style prompt that makes the model emit a strict JSON spec. */
-function specPrompt(kind: DocKind, input: string): string {
+function specPrompt(kind: DocKind, input: string, context?: string): string {
+  const contextBlock = context
+    ? [
+        "Recent conversation (the request may refer to it — e.g. \"this\", \"that\", \"the above\"):",
+        context,
+        "",
+      ]
+    : [];
   if (kind === "pptx") {
     return [
       "You are a presentation generator. Based on the user request below, output ONLY a single valid minified JSON object — no markdown, no code fences, no commentary.",
       "",
+      ...contextBlock,
       `User request: "${input}"`,
       "",
       "JSON schema:",
@@ -57,6 +70,7 @@ function specPrompt(kind: DocKind, input: string): string {
   return [
     "You are a document generator. Based on the user request below, output ONLY a single valid minified JSON object — no markdown, no code fences, no commentary.",
     "",
+    ...contextBlock,
     `User request: "${input}"`,
     "",
     "JSON schema:",
@@ -71,22 +85,80 @@ function specPrompt(kind: DocKind, input: string): string {
 }
 
 /** Pull the first balanced JSON object out of a model response. */
-function extractJson(raw: string): string {
+export function extractJson(raw: string): string {
   let text = raw.trim();
   // Strip code fences if the model added them despite instructions.
   text = text.replace(/^```(?:json)?/i, "").replace(/```$/i, "").trim();
   const start = text.indexOf("{");
-  const end = text.lastIndexOf("}");
-  if (start === -1 || end === -1 || end <= start) {
+  if (start === -1) {
     throw new Error("Model did not return a JSON document spec.");
   }
-  return text.slice(start, end + 1);
+  const end = text.lastIndexOf("}");
+  // A truncated response may lack the closing brace entirely — hand the tail
+  // to the repair pass rather than failing here.
+  return text.slice(start, end > start ? end + 1 : undefined);
+}
+
+/**
+ * Best-effort repair of a truncated JSON object: walks the text respecting
+ * string/escape state, drops a dangling partial token, strips a trailing
+ * comma, and closes any still-open brackets/braces. Returns null when the
+ * result still doesn't parse.
+ */
+export function repairJson(candidate: string): string | null {
+  let inString = false;
+  let escaped = false;
+  const stack: string[] = [];
+  let lastComplete = -1;
+  for (let i = 0; i < candidate.length; i++) {
+    const ch = candidate[i];
+    if (inString) {
+      if (escaped) escaped = false;
+      else if (ch === "\\") escaped = true;
+      else if (ch === '"') { inString = false; lastComplete = i; }
+      continue;
+    }
+    if (ch === '"') { inString = true; continue; }
+    if (ch === "{" || ch === "[") { stack.push(ch === "{" ? "}" : "]"); continue; }
+    if (ch === "}" || ch === "]") { stack.pop(); lastComplete = i; continue; }
+    if (!/\s/.test(ch)) lastComplete = i;
+  }
+  // Cut back to the last complete token (drops an unterminated string or a
+  // dangling `"key":` fragment), then strip a trailing comma or colon-fragment.
+  let text = candidate.slice(0, lastComplete + 1);
+  text = text.replace(/,\s*$/, "").replace(/"[^"]*"\s*:\s*$/, "").replace(/,\s*$/, "");
+  // Re-scan what remains to find which brackets are still open.
+  inString = false;
+  escaped = false;
+  stack.length = 0;
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    if (inString) {
+      if (escaped) escaped = false;
+      else if (ch === "\\") escaped = true;
+      else if (ch === '"') inString = false;
+      continue;
+    }
+    if (ch === '"') inString = true;
+    else if (ch === "{" || ch === "[") stack.push(ch === "{" ? "}" : "]");
+    else if (ch === "}" || ch === "]") stack.pop();
+  }
+  if (inString) text += '"';
+  while (stack.length) text += stack.pop();
+  try {
+    JSON.parse(text);
+    return text;
+  } catch {
+    return null;
+  }
 }
 
 interface GenerateOptions {
   model: string;
   ollamaUrl?: string | null;
   maxTokens?: number;
+  /** Recent conversation snippet so requests like "…on this" resolve. */
+  context?: string;
   onPhase?: (phase: string) => void;
 }
 
@@ -103,15 +175,28 @@ export async function generateDocument(
   opts.onPhase?.(`Drafting ${label} outline with ${opts.model}…`);
 
   const raw = await invoke<string>("query_ollama", {
-    prompt: specPrompt(kind, input),
+    prompt: specPrompt(kind, input, opts.context),
     model: opts.model,
     ollamaUrl: opts.ollamaUrl ?? null,
-    maxTokens: opts.maxTokens ?? 4096,
+    maxTokens: Math.max(opts.maxTokens ?? 0, MIN_SPEC_TOKENS),
   });
 
-  const specJson = extractJson(raw);
-  // Validate it parses before sending to the backend for a clearer error.
-  JSON.parse(specJson);
+  const candidate = extractJson(raw);
+  let specJson: string;
+  try {
+    JSON.parse(candidate);
+    specJson = candidate;
+  } catch {
+    const repaired = repairJson(candidate);
+    if (!repaired) {
+      throw new Error(
+        `The ${label} outline from ${opts.model} came back incomplete or malformed ` +
+          "(often a truncated response). Try again, ask for a shorter " +
+          `${label}, or raise Max Tokens in Settings.`,
+      );
+    }
+    specJson = repaired;
+  }
 
   opts.onPhase?.(`Writing ${kind === "pptx" ? "PowerPoint" : "Word"} file…`);
   const command = kind === "pptx" ? "create_powerpoint" : "create_word_document";

--- a/src/test/docGen.test.ts
+++ b/src/test/docGen.test.ts
@@ -1,0 +1,89 @@
+// docGen unit tests — detection, JSON extraction, truncation repair.
+//
+// Regression coverage for the field failure: "create a word document on this"
+// → model outline truncated at the 2048-token chat cap → raw
+// `SyntaxError: JSON Parse error: Expected ']'` surfaced to the user.
+
+import { describe, it, expect } from "vitest";
+import { detectDocRequest, extractJson, repairJson } from "../lib/docGen";
+
+describe("detectDocRequest", () => {
+  it("detects classic phrasings", () => {
+    expect(detectDocRequest("create a presentation about AI")).toBe("pptx");
+    expect(detectDocRequest("make me a PowerPoint on sales")).toBe("pptx");
+    expect(detectDocRequest("generate slides for standup")).toBe("pptx");
+    expect(detectDocRequest("create a word document on this")).toBe("docx");
+    expect(detectDocRequest("write a report about Q3")).toBe("docx");
+  });
+
+  it("detects the short forms people actually type (ppt / doc)", () => {
+    expect(detectDocRequest("create a ppt about sales")).toBe("pptx");
+    expect(detectDocRequest("make a ppt")).toBe("pptx");
+    expect(detectDocRequest("create a doc about the roadmap")).toBe("docx");
+  });
+
+  it("requires a creation verb", () => {
+    expect(detectDocRequest("what is a powerpoint?")).toBeNull();
+    expect(detectDocRequest("the document says otherwise")).toBeNull();
+  });
+
+  it("ignores unrelated requests", () => {
+    expect(detectDocRequest("create a shopping list")).toBeNull();
+    expect(detectDocRequest("how do you work")).toBeNull();
+  });
+});
+
+describe("extractJson", () => {
+  it("strips code fences and surrounding prose", () => {
+    const raw = 'Here you go:\n```json\n{"title":"T","slides":[]}\n```';
+    expect(JSON.parse(extractJson(raw))).toEqual({ title: "T", slides: [] });
+  });
+
+  it("returns the tail for repair when the closing brace is missing", () => {
+    const raw = '{"title":"T","slides":[{"title":"S1","bullets":["a","b"';
+    expect(extractJson(raw)).toBe(raw);
+  });
+
+  it("throws when there is no JSON at all", () => {
+    expect(() => extractJson("Sorry, I cannot do that.")).toThrow();
+  });
+});
+
+describe("repairJson", () => {
+  it("closes a spec truncated mid-array (the field failure shape)", () => {
+    const truncated =
+      '{"title":"Report","subtitle":"S","sections":[{"heading":"H1","paragraphs":["p1","p2"],"bullets":["b1","b2"';
+    const fixed = repairJson(truncated);
+    expect(fixed).not.toBeNull();
+    const obj = JSON.parse(fixed!);
+    expect(obj.sections[0].bullets).toEqual(["b1", "b2"]);
+  });
+
+  it("drops an unterminated trailing string", () => {
+    const truncated = '{"title":"T","slides":[{"title":"S1","bullets":["complete","cut off mid sente';
+    const fixed = repairJson(truncated);
+    expect(fixed).not.toBeNull();
+    const obj = JSON.parse(fixed!);
+    expect(obj.slides[0].bullets[0]).toBe("complete");
+  });
+
+  it("drops a dangling key fragment", () => {
+    const truncated = '{"title":"T","slides":[{"title":"S1","bullets":["a"]},{"title":';
+    const fixed = repairJson(truncated);
+    expect(fixed).not.toBeNull();
+    const obj = JSON.parse(fixed!);
+    expect(obj.slides.length).toBeGreaterThanOrEqual(1);
+    expect(obj.slides[0].bullets).toEqual(["a"]);
+  });
+
+  it("keeps already-valid JSON semantically intact", () => {
+    const ok = '{"title":"T","slides":[{"title":"S","bullets":["x"]}]}';
+    const fixed = repairJson(ok);
+    expect(fixed).not.toBeNull();
+    expect(JSON.parse(fixed!)).toEqual(JSON.parse(ok));
+  });
+
+  it("returns null for hopeless input", () => {
+    expect(repairJson("not json at all")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Description

Field failure today: "create a word document on this" → `⚠️ SyntaxError: JSON Parse error: Expected ']'`. Three compounding causes, all fixed:

1. **Token starvation** — the doc-spec call was capped by the chat Max Tokens slider (default 2048). A Word spec with full paragraphs (plus a reasoning model's trace, which counts against the same budget) regularly exceeds that → truncated JSON. docGen now enforces a **dedicated 8192-token floor** for spec generation.
2. **No conversation context** — the spec prompt only saw the raw input, so "…on this" pointed at nothing. useChat now passes the **last few messages** (trimmed to ~1600 chars) and the prompt tells the model the request may refer to them.
3. **No repair, opaque error** — a truncated spec surfaced as a raw SyntaxError. Added `repairJson`: a string/escape-aware scanner that drops dangling fragments, strips trailing commas, and closes open brackets; if repair still fails the user gets an actionable message (try again / shorter / raise Max Tokens) instead of a parse trace.

Also: `detectDocRequest` now catches **"ppt"** and **"doc"** (previously only powerpoint/presentation/document/… — "create a ppt about sales" silently fell through to plain chat).

Verified against the live daemon: the exact spec prompt on qwen3.8:27b returns clean parseable JSON (6 slides, 220 tokens); the docx shape at 2048 tokens is what truncates in the field.

## Type of Change

- [x] 🔧 Bug fix (non-breaking change which fixes an issue)

## Checks

- `npx vitest run` — **188/188** (12 new docGen tests: detection incl. ppt/doc, fence stripping, truncation repair shapes)
- `npx tsc --noEmit` — clean
- Frontend-only change; no Rust touched.