### PR TITLE
Doc-gen detection: survive verb typos, accept verb-less topics, never fire on read requests

### DIFF
--- a/src/lib/docGen.ts
+++ b/src/lib/docGen.ts
@@ -19,13 +19,55 @@ const MIN_SPEC_TOKENS = 8192;
  * Requires a creation verb plus a document/presentation noun to avoid firing
  * on ordinary questions that merely mention the word "document".
  */
-export function detectDocRequest(input: string): DocKind | null {
-  const t = input.toLowerCase();
-  const createVerb =
+const CREATE_VERBS = [
+  "create", "make", "generate", "build", "write", "draft", "prepare",
+  "produce", "design", "give",
+];
+
+/** Edit distance ≤ 1 (one substitution, insertion, or deletion). Catches the
+ *  imperative-typo class — "reate a word document…", "mke a ppt…" — that a
+ *  strict word-boundary regex silently drops into plain chat. */
+function withinOneEdit(a: string, b: string): boolean {
+  if (a === b) return true;
+  const la = a.length, lb = b.length;
+  if (Math.abs(la - lb) > 1) return false;
+  let i = 0, j = 0, edits = 0;
+  while (i < la && j < lb) {
+    if (a[i] === b[j]) { i++; j++; continue; }
+    if (++edits > 1) return false;
+    if (la === lb) { i++; j++; }        // substitution
+    else if (la > lb) { i++; }           // deletion from a
+    else { j++; }                        // insertion into a
+  }
+  return edits + (la - i) + (lb - j) <= 1;
+}
+
+function hasCreateVerb(t: string): boolean {
+  if (
     /\b(create|make|generate|build|write|draft|prepare|produce|design|put together|give me)\b/.test(
       t,
-    );
-  if (!createVerb) return null;
+    )
+  ) {
+    return true;
+  }
+  // Fuzzy pass over the first few tokens for one-letter typos.
+  const tokens = t.split(/[^a-z]+/).filter(Boolean).slice(0, 3);
+  return tokens.some(
+    (tok) => tok.length >= 3 && CREATE_VERBS.some((v) => withinOneEdit(tok, v)),
+  );
+}
+
+/** Questions and read-style requests about an existing document must never
+ *  trigger generation. */
+function looksLikeReadRequest(t: string): boolean {
+  return (
+    /^(what|who|where|when|why|how|is|are|does|do|can|could|should|would|did)\b/.test(t) ||
+    /\b(read|open|summariz|explain|analyz|review|check|look at|compare|translate)/.test(t)
+  );
+}
+
+export function detectDocRequest(input: string): DocKind | null {
+  const t = input.toLowerCase().trim();
 
   const pptWords =
     /\b(power\s?point|pptx?|presentation|slide\s?deck|slides?|slideshow|deck)\b/.test(
@@ -35,10 +77,17 @@ export function detectDocRequest(input: string): DocKind | null {
     /\b(word\s+document|word\s+doc|docx?|word\s+file|\bdocument\b|report|write-?up|essay|letter|memo|brief)\b/.test(
       t,
     );
+  if (!pptWords && !docWords) return null;
+
+  if (looksLikeReadRequest(t)) return null;
+
+  // A recognized (or one-typo-off) creation verb is the primary signal; a
+  // verb-less "word document on/about X" style request is accepted too.
+  const topicMarker = /\b(pptx?|docx?|power\s?point|presentation|document|doc|report|slide\s?deck|slides|deck|memo|letter|essay|brief)\b\s+(on|about|for|of|covering|regarding)\b/.test(t);
+  if (!hasCreateVerb(t) && !topicMarker) return null;
 
   if (pptWords) return "pptx";
-  if (docWords) return "docx";
-  return null;
+  return "docx";
 }
 
 /** Build the system-style prompt that makes the model emit a strict JSON spec. */

--- a/src/test/docGen.test.ts
+++ b/src/test/docGen.test.ts
@@ -31,6 +31,24 @@ describe("detectDocRequest", () => {
     expect(detectDocRequest("create a shopping list")).toBeNull();
     expect(detectDocRequest("how do you work")).toBeNull();
   });
+
+  it("survives one-letter verb typos (the field failure)", () => {
+    expect(detectDocRequest("reate a word document on this")).toBe("docx");
+    expect(detectDocRequest("mke a ppt about sales")).toBe("pptx");
+    expect(detectDocRequest("creat a presentation on Q3")).toBe("pptx");
+  });
+
+  it("accepts verb-less topic phrasings", () => {
+    expect(detectDocRequest("word document on climate change")).toBe("docx");
+    expect(detectDocRequest("a presentation about our roadmap")).toBe("pptx");
+  });
+
+  it("never fires on questions or read-style requests about documents", () => {
+    expect(detectDocRequest("what's in the word document on my desk?")).toBeNull();
+    expect(detectDocRequest("summarize the report about Q3")).toBeNull();
+    expect(detectDocRequest("can you read the document about the merger")).toBeNull();
+    expect(detectDocRequest("review the presentation for errors")).toBeNull();
+  });
 });
 
 describe("extractJson", () => {


### PR DESCRIPTION
## Description

Second field failure tonight: the user typed **"reate a word document on this"** (missing `c`) — no recognized creation verb, so detection returned null and plain chat answered with an unhelpful "I cannot create files" essay.

- **Fuzzy verb matching** — first three tokens are checked within edit distance 1 of the create-verb list (`reate`→create, `mke`→make, `creat`→create). Tiny two-pointer implementation, no deps.
- **Verb-less topic phrasings accepted** — "word document on climate change", "a presentation about our roadmap" now trigger via a noun+topic-marker rule.
- **Read-request guard** — questions ("what's in the word document on my desk?") and read-style verbs (read/open/summarize/explain/analyze/review/…) never trigger generation, keeping the broader matching safe.

## Type of Change

- [x] 🔧 Bug fix (non-breaking change which fixes an issue)

## Checks

- `npx vitest run` — **191/191** (3 new test groups: typo survival incl. the exact field input, verb-less phrasings, read-request negatives)
- `npx tsc --noEmit` — clean
- Frontend-only.