### PR TITLE
Web Research: opt-in, user-directed live-data exploration (web + screen lanes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,18 @@ Two honest caveats, because "100% offline" gets thrown around too loosely:
 - The **installer** downloads from GitHub, and **Ollama** downloads model
   weights the first time. After that, no network is required or used.
 - The optional **Email Keeper** agent connects to *your* IMAP server if you
-  configure it. It is off by default and it is the only feature that talks to
-  anything beyond localhost. Leave it off and the app has no reason to open a
-  socket.
+  configure it. It is off by default.
+- The optional **Web Research** feature fetches web pages — but only the URLs
+  you explicitly type into chat, over HTTPS, with localhost/LAN addresses
+  refused. It is off by default, double-gated (a Settings toggle plus a
+  Rust-side gate that hard-refuses fetches while disabled), uses no search
+  engine, and sends nothing in the background. The zero-network alternative is
+  built in: open the page and ask PrismOS to *read your screen* — local vision
+  only.
+
+Email Keeper and Web Research are the only two features that can talk to
+anything beyond localhost. Leave both off — the default — and the app has no
+reason to open a socket.
 
 ---
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -25,6 +25,7 @@ mod model_tracker;
 mod brain_wrapped;
 mod doc_generator;
 mod project_reviewer;
+mod web_research;
 
 use std::sync::Mutex;
 use std::sync::Arc;
@@ -452,6 +453,32 @@ async fn create_text_file(
     }
 
     serde_json::to_string(&generated).map_err(|e| e.to_string())
+}
+
+// ─── Web Research — opt-in, user-directed HTTPS fetching ─────────────────────
+
+/// Sync the Rust-side Web Research gate with the Settings toggle. The gate
+/// always starts OFF on launch; the frontend re-applies the persisted setting.
+#[tauri::command]
+async fn set_web_research_enabled(enabled: bool) -> Result<bool, String> {
+    web_research::set_enabled(enabled);
+    Ok(web_research::is_enabled())
+}
+
+/// research_fetch_url — Fetch ONE user-named https:// URL and return its
+/// readable text as JSON ({url,title,text,truncated}). Hard-refused unless the
+/// user has enabled Web Research in Settings; https-only; localhost and
+/// private/LAN addresses are always rejected. Every fetch is audit-logged.
+#[tauri::command]
+async fn research_fetch_url(app: tauri::AppHandle, url: String) -> Result<String, String> {
+    let page = web_research::fetch_url_as_text(&url).await?;
+
+    if let Ok(app_dir) = app.path().app_data_dir() {
+        let audit = audit_log::AuditLog::new(&app_dir);
+        let _ = audit.append("research_fetch_url", "user", &page.url);
+    }
+
+    serde_json::to_string(&page).map_err(|e| e.to_string())
 }
 
 /// open_generated_file — Open a generated file (or reveal its folder) with the
@@ -3214,6 +3241,9 @@ pub fn run() {
             create_powerpoint,
             create_text_file,
             open_generated_file,
+            // Web Research — opt-in, user-directed HTTPS fetching
+            set_web_research_enabled,
+            research_fetch_url,
             // Project Review — gated, read-only whole-project review
             scan_project_for_review,
             run_project_review,

--- a/src-tauri/src/web_research.rs
+++ b/src-tauri/src/web_research.rs
@@ -16,6 +16,7 @@
 // size-capped before it is handed to the local model for synthesis.
 
 use serde::Serialize;
+use std::net::{IpAddr, SocketAddr};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
@@ -25,6 +26,8 @@ use std::time::Duration;
 static WEB_RESEARCH_ENABLED: AtomicBool = AtomicBool::new(false);
 
 const FETCH_TIMEOUT: Duration = Duration::from_secs(20);
+/// Redirects are followed manually so every hop is re-validated.
+const MAX_REDIRECTS: usize = 5;
 /// Hard cap on downloaded bytes per page (streamed, so an endless response
 /// can't balloon memory).
 const MAX_FETCH_BYTES: usize = 2 * 1024 * 1024;
@@ -84,29 +87,92 @@ pub fn validate_url(url: &str) -> Result<String, String> {
     Ok(host_lc)
 }
 
-/// True for localhost, .local, and RFC-1918 / link-local / loopback addresses.
+/// True for localhost-style names and non-public IP literals. Prefix checks
+/// apply only to PARSED IP addresses — a domain like fcc.gov or fda.gov must
+/// never be mistaken for an fc00::/7 literal.
 fn is_private_host(host: &str) -> bool {
-    if host == "localhost" || host == "0.0.0.0" || host.ends_with(".local") || host.ends_with(".localhost") {
+    if host == "localhost" || host.ends_with(".local") || host.ends_with(".localhost") {
         return true;
     }
-    if host == "::1" || host.starts_with("fe80:") || host.starts_with("fc") || host.starts_with("fd") {
-        return true; // IPv6 loopback / link-local / unique-local
+    match host.parse::<IpAddr>() {
+        Ok(ip) => is_private_ip(&ip),
+        Err(_) => false, // a real hostname — its resolved IPs are checked separately
     }
-    let octets: Vec<u8> = host
-        .split('.')
-        .filter_map(|p| p.parse::<u8>().ok())
+}
+
+/// True for any IP that must never be fetched: loopback, unspecified,
+/// RFC-1918, link-local, CGNAT, multicast/broadcast, IPv6 ULA, and
+/// IPv4-mapped forms of any of those.
+fn is_private_ip(ip: &IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => {
+            let o = v4.octets();
+            v4.is_loopback()
+                || v4.is_unspecified()
+                || v4.is_private()          // 10/8, 172.16/12, 192.168/16
+                || v4.is_link_local()       // 169.254/16
+                || v4.is_broadcast()
+                || v4.is_multicast()
+                || o[0] == 0                // 0.0.0.0/8
+                || (o[0] == 100 && (64..=127).contains(&o[1])) // 100.64/10 CGNAT
+        }
+        IpAddr::V6(v6) => {
+            if let Some(mapped) = v6.to_ipv4_mapped() {
+                return is_private_ip(&IpAddr::V4(mapped));
+            }
+            let s = v6.segments();
+            v6.is_loopback()
+                || v6.is_unspecified()
+                || v6.is_multicast()
+                || (s[0] & 0xffc0) == 0xfe80 // link-local fe80::/10
+                || (s[0] & 0xfe00) == 0xfc00 // unique-local fc00::/7
+        }
+    }
+}
+
+/// Resolve a host and return socket addrs, refusing if ANY resolved address
+/// is non-public (a public hostname must not be usable to reach the LAN via
+/// DNS tricks). IP literals skip DNS entirely.
+async fn resolve_public(host: &str, port: u16) -> Result<Vec<SocketAddr>, String> {
+    if let Ok(ip) = host.parse::<IpAddr>() {
+        // Already vetted by validate_url, but keep the invariant local.
+        if is_private_ip(&ip) {
+            return Err(format!("\"{host}\" is a local/private address."));
+        }
+        return Ok(vec![SocketAddr::new(ip, port)]);
+    }
+    let addrs: Vec<SocketAddr> = tokio::net::lookup_host((host, port))
+        .await
+        .map_err(|e| format!("Could not resolve \"{host}\": {e}"))?
         .collect();
-    if octets.len() == 4 && host.split('.').count() == 4 {
-        return match (octets[0], octets[1]) {
-            (127, _) => true,           // loopback
-            (10, _) => true,            // RFC-1918
-            (192, 168) => true,         // RFC-1918
-            (172, b) if (16..=31).contains(&b) => true, // RFC-1918
-            (169, 254) => true,         // link-local
-            _ => false,
-        };
+    if addrs.is_empty() {
+        return Err(format!("\"{host}\" did not resolve to any address."));
     }
-    false
+    if let Some(bad) = addrs.iter().find(|a| is_private_ip(&a.ip())) {
+        return Err(format!(
+            "\"{host}\" resolves to a local/private address ({}) — refusing to fetch.",
+            bad.ip()
+        ));
+    }
+    Ok(addrs)
+}
+
+/// Port from an https URL's authority (default 443).
+fn url_port(url: &str) -> u16 {
+    let rest = url.trim().strip_prefix("https://").unwrap_or("");
+    let authority = rest.split(['/', '?', '#']).next().unwrap_or("");
+    if authority.starts_with('[') {
+        // [v6]:port
+        authority
+            .rsplit_once("]:")
+            .and_then(|(_, p)| p.parse().ok())
+            .unwrap_or(443)
+    } else {
+        authority
+            .rsplit_once(':')
+            .and_then(|(_, p)| p.parse().ok())
+            .unwrap_or(443)
+    }
 }
 
 /// Fetch a single user-named URL and return its readable text.
@@ -119,29 +185,53 @@ pub async fn fetch_url_as_text(url: &str) -> Result<FetchedPage, String> {
                 .to_string(),
         );
     }
-    validate_url(url)?;
+    // Redirects are followed MANUALLY so that every hop — not just the final
+    // landing URL — is validated at the name level AND at the resolved-IP
+    // level (DNS pinned via resolve_to_addrs, closing the rebinding window
+    // between the check and the connect).
+    let mut current = url.trim().to_string();
+    let mut resp = None;
+    for _hop in 0..=MAX_REDIRECTS {
+        let host = validate_url(&current)?;
+        let port = url_port(&current);
+        let addrs = resolve_public(&host, port).await?;
 
-    let client = reqwest::Client::builder()
-        .timeout(FETCH_TIMEOUT)
-        .redirect(reqwest::redirect::Policy::limited(5))
-        .user_agent("PrismOS-AI/0.6 (local research; user-directed)")
-        .build()
-        .map_err(|e| e.to_string())?;
+        let client = reqwest::Client::builder()
+            .timeout(FETCH_TIMEOUT)
+            .redirect(reqwest::redirect::Policy::none())
+            .resolve_to_addrs(&host, &addrs)
+            .user_agent("PrismOS-AI/0.6 (local research; user-directed)")
+            .build()
+            .map_err(|e| e.to_string())?;
 
-    let mut resp = client
-        .get(url.trim())
-        .send()
-        .await
-        .map_err(|e| format!("Fetch failed: {e}"))?;
+        let r = client
+            .get(&current)
+            .send()
+            .await
+            .map_err(|e| format!("Fetch failed: {e}"))?;
+
+        if r.status().is_redirection() {
+            let loc = r
+                .headers()
+                .get(reqwest::header::LOCATION)
+                .and_then(|v| v.to_str().ok())
+                .ok_or_else(|| "Redirect without a Location header.".to_string())?;
+            let next = r
+                .url()
+                .join(loc)
+                .map_err(|e| format!("Bad redirect target: {e}"))?;
+            current = next.to_string();
+            continue;
+        }
+        resp = Some(r);
+        break;
+    }
+    let mut resp = resp.ok_or_else(|| "Too many redirects.".to_string())?;
 
     if !resp.status().is_success() {
         return Err(format!("Fetch failed: HTTP {}", resp.status()));
     }
-    // Re-validate where redirects actually landed — a public URL must not be
-    // able to bounce us onto localhost or the LAN.
     let final_url = resp.url().to_string();
-    validate_url(&final_url)
-        .map_err(|e| format!("Redirected to a non-fetchable address: {e}"))?;
 
     let mut bytes: Vec<u8> = Vec::new();
     let mut truncated = false;
@@ -333,6 +423,41 @@ mod tests {
         // 172.32.x is public; 172.15.x is public.
         assert!(validate_url("https://172.32.0.1/").is_ok());
         assert!(validate_url("https://172.15.0.1/").is_ok());
+    }
+
+    #[test]
+    fn domains_starting_with_fc_fd_are_not_ipv6_literals() {
+        // Regression: a string-prefix check once misclassified these as
+        // fc00::/7 unique-local addresses.
+        assert_eq!(validate_url("https://fcc.gov/").unwrap(), "fcc.gov");
+        assert_eq!(validate_url("https://fda.gov/about").unwrap(), "fda.gov");
+        assert_eq!(validate_url("https://fe80cars.example.com/").unwrap(), "fe80cars.example.com");
+    }
+
+    #[test]
+    fn is_private_ip_classifies_correctly() {
+        let private = [
+            "127.0.0.1", "10.1.2.3", "172.16.0.1", "192.168.0.1", "169.254.9.9",
+            "0.0.0.0", "100.64.0.1", "::1", "fe80::1", "fc00::1", "fd12::1",
+            "::ffff:192.168.0.1", // IPv4-mapped private
+        ];
+        for p in private {
+            let ip: IpAddr = p.parse().unwrap();
+            assert!(is_private_ip(&ip), "should be private: {p}");
+        }
+        let public = ["8.8.8.8", "1.1.1.1", "172.32.0.1", "100.128.0.1", "2606:4700::1111"];
+        for p in public {
+            let ip: IpAddr = p.parse().unwrap();
+            assert!(!is_private_ip(&ip), "should be public: {p}");
+        }
+    }
+
+    #[test]
+    fn url_port_parses_defaults_and_explicit() {
+        assert_eq!(url_port("https://example.com/x"), 443);
+        assert_eq!(url_port("https://example.com:8443/x"), 8443);
+        assert_eq!(url_port("https://[2606:4700::1111]/x"), 443);
+        assert_eq!(url_port("https://[2606:4700::1111]:9443/x"), 9443);
     }
 
     #[test]

--- a/src-tauri/src/web_research.rs
+++ b/src-tauri/src/web_research.rs
@@ -1,0 +1,386 @@
+// Web Research — opt-in, user-directed HTTPS page fetching.
+//
+// PrismOS is offline-first: this module is the ONLY code path (besides the
+// optional Email Keeper) that can talk to anything beyond localhost, and it
+// is tripled-gated:
+//
+//   1. OFF by default — a process-wide AtomicBool that starts `false` on every
+//      launch. The frontend Settings toggle must explicitly enable it.
+//   2. User-directed only — it fetches exactly the URLs the user typed. There
+//      is no search engine, no crawling, no telemetry, no background use.
+//   3. HTTPS-only, public hosts only — plain http, localhost, and private/
+//      link-local LAN addresses are refused, so a chat message can never be
+//      used to probe the user's own machine or network.
+//
+// Fetched HTML is reduced to plain text locally (script/style stripped) and
+// size-capped before it is handed to the local model for synthesis.
+
+use serde::Serialize;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+/// Process-wide enable flag. Always starts disabled; the Settings toggle
+/// (persisted by the frontend) re-enables it on each launch via the
+/// `set_web_research_enabled` command.
+static WEB_RESEARCH_ENABLED: AtomicBool = AtomicBool::new(false);
+
+const FETCH_TIMEOUT: Duration = Duration::from_secs(20);
+/// Hard cap on downloaded bytes per page (streamed, so an endless response
+/// can't balloon memory).
+const MAX_FETCH_BYTES: usize = 2 * 1024 * 1024;
+/// Cap on the extracted plain text handed back over IPC.
+const MAX_TEXT_CHARS: usize = 40_000;
+
+pub fn set_enabled(enabled: bool) {
+    WEB_RESEARCH_ENABLED.store(enabled, Ordering::SeqCst);
+}
+
+pub fn is_enabled() -> bool {
+    WEB_RESEARCH_ENABLED.load(Ordering::SeqCst)
+}
+
+#[derive(Serialize)]
+pub struct FetchedPage {
+    pub url: String,
+    pub title: String,
+    pub text: String,
+    pub truncated: bool,
+}
+
+/// Validate that a URL is https and points at a public host.
+/// Returns the host on success (used for logging), or a user-facing error.
+pub fn validate_url(url: &str) -> Result<String, String> {
+    let trimmed = url.trim();
+    let rest = trimmed
+        .strip_prefix("https://")
+        .ok_or_else(|| "Only https:// URLs can be fetched.".to_string())?;
+    // host = up to the first '/', '?' or '#'; then strip :port and userinfo.
+    let authority = rest
+        .split(['/', '?', '#'])
+        .next()
+        .unwrap_or("")
+        .trim();
+    if authority.is_empty() {
+        return Err("URL has no host.".to_string());
+    }
+    if authority.contains('@') {
+        return Err("URLs with embedded credentials are not allowed.".to_string());
+    }
+    // IPv6 literal like [::1]:443 — keep the bracketed part as the host.
+    let host = if let Some(stripped) = authority.strip_prefix('[') {
+        stripped.split(']').next().unwrap_or("").to_string()
+    } else {
+        authority.split(':').next().unwrap_or("").to_string()
+    };
+    let host_lc = host.to_lowercase();
+    if host_lc.is_empty() {
+        return Err("URL has no host.".to_string());
+    }
+    if is_private_host(&host_lc) {
+        return Err(format!(
+            "\"{host_lc}\" is a local/private address — Web Research only fetches public sites."
+        ));
+    }
+    Ok(host_lc)
+}
+
+/// True for localhost, .local, and RFC-1918 / link-local / loopback addresses.
+fn is_private_host(host: &str) -> bool {
+    if host == "localhost" || host == "0.0.0.0" || host.ends_with(".local") || host.ends_with(".localhost") {
+        return true;
+    }
+    if host == "::1" || host.starts_with("fe80:") || host.starts_with("fc") || host.starts_with("fd") {
+        return true; // IPv6 loopback / link-local / unique-local
+    }
+    let octets: Vec<u8> = host
+        .split('.')
+        .filter_map(|p| p.parse::<u8>().ok())
+        .collect();
+    if octets.len() == 4 && host.split('.').count() == 4 {
+        return match (octets[0], octets[1]) {
+            (127, _) => true,           // loopback
+            (10, _) => true,            // RFC-1918
+            (192, 168) => true,         // RFC-1918
+            (172, b) if (16..=31).contains(&b) => true, // RFC-1918
+            (169, 254) => true,         // link-local
+            _ => false,
+        };
+    }
+    false
+}
+
+/// Fetch a single user-named URL and return its readable text.
+/// Refuses immediately when the feature is disabled.
+pub async fn fetch_url_as_text(url: &str) -> Result<FetchedPage, String> {
+    if !is_enabled() {
+        return Err(
+            "Web Research is disabled (PrismOS is offline by default). \
+             Enable it in Settings → 🌐 Web Research first."
+                .to_string(),
+        );
+    }
+    validate_url(url)?;
+
+    let client = reqwest::Client::builder()
+        .timeout(FETCH_TIMEOUT)
+        .redirect(reqwest::redirect::Policy::limited(5))
+        .user_agent("PrismOS-AI/0.6 (local research; user-directed)")
+        .build()
+        .map_err(|e| e.to_string())?;
+
+    let mut resp = client
+        .get(url.trim())
+        .send()
+        .await
+        .map_err(|e| format!("Fetch failed: {e}"))?;
+
+    if !resp.status().is_success() {
+        return Err(format!("Fetch failed: HTTP {}", resp.status()));
+    }
+    // Re-validate where redirects actually landed — a public URL must not be
+    // able to bounce us onto localhost or the LAN.
+    let final_url = resp.url().to_string();
+    validate_url(&final_url)
+        .map_err(|e| format!("Redirected to a non-fetchable address: {e}"))?;
+
+    let mut bytes: Vec<u8> = Vec::new();
+    let mut truncated = false;
+    while let Some(chunk) = resp.chunk().await.map_err(|e| e.to_string())? {
+        if bytes.len() + chunk.len() > MAX_FETCH_BYTES {
+            bytes.extend_from_slice(&chunk[..MAX_FETCH_BYTES - bytes.len()]);
+            truncated = true;
+            break;
+        }
+        bytes.extend_from_slice(&chunk);
+    }
+    let body = String::from_utf8_lossy(&bytes);
+
+    let title = extract_title(&body).unwrap_or_else(|| url.trim().to_string());
+    let mut text = html_to_text(&body);
+    if text.chars().count() > MAX_TEXT_CHARS {
+        text = text.chars().take(MAX_TEXT_CHARS).collect();
+        truncated = true;
+    }
+    if text.trim().is_empty() {
+        return Err("The page had no readable text (it may be script-rendered or non-HTML).".to_string());
+    }
+
+    Ok(FetchedPage {
+        url: final_url,
+        title,
+        text,
+        truncated,
+    })
+}
+
+/// ASCII-only lowercase that preserves byte offsets exactly (Unicode
+/// `to_lowercase()` can change byte lengths — e.g. 'İ' — which would
+/// misalign indices found in the lowered copy against the original).
+fn ascii_lower(s: &str) -> String {
+    s.chars().map(|c| c.to_ascii_lowercase()).collect()
+}
+
+fn extract_title(html: &str) -> Option<String> {
+    let lower = ascii_lower(html);
+    let start = lower.find("<title")?;
+    let open_end = html[start..].find('>')? + start + 1;
+    let close = lower[open_end..].find("</title")? + open_end;
+    let raw = decode_entities(html[open_end..close].trim());
+    if raw.is_empty() { None } else { Some(raw) }
+}
+
+/// Reduce HTML to readable plain text: drop script/style/noscript bodies,
+/// strip tags (block-level tags become newlines), decode common entities,
+/// collapse whitespace. Deliberately dependency-free.
+pub fn html_to_text(html: &str) -> String {
+    let cleaned = strip_element(html, "script");
+    let cleaned = strip_element(&cleaned, "style");
+    let cleaned = strip_element(&cleaned, "noscript");
+
+    let mut out = String::with_capacity(cleaned.len() / 2);
+    let mut chars = cleaned.char_indices().peekable();
+    while let Some((i, ch)) = chars.next() {
+        if ch == '<' {
+            // Peek the tag name to decide whether it breaks a line.
+            let rest = &cleaned[i + 1..];
+            let tag: String = rest
+                .chars()
+                .take_while(|c| c.is_ascii_alphanumeric() || *c == '/')
+                .collect::<String>()
+                .to_lowercase();
+            let name = tag.trim_start_matches('/');
+            if matches!(
+                name,
+                "p" | "br" | "div" | "li" | "tr" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6"
+                    | "section" | "article" | "table" | "ul" | "ol" | "blockquote"
+            ) {
+                out.push('\n');
+            }
+            // Skip to the closing '>'.
+            for (_, c) in chars.by_ref() {
+                if c == '>' {
+                    break;
+                }
+            }
+            continue;
+        }
+        out.push(ch);
+    }
+
+    collapse_whitespace(&decode_entities(&out))
+}
+
+/// Remove `<name …>…</name>` blocks case-insensitively (script/style/noscript).
+fn strip_element(html: &str, name: &str) -> String {
+    let lower = ascii_lower(html);
+    let open_pat = format!("<{name}");
+    let close_pat = format!("</{name}");
+    let mut out = String::with_capacity(html.len());
+    let mut pos = 0;
+    while let Some(rel) = lower[pos..].find(&open_pat) {
+        let start = pos + rel;
+        out.push_str(&html[pos..start]);
+        match lower[start..].find(&close_pat) {
+            Some(close_rel) => {
+                let close_start = start + close_rel;
+                // Skip past the closing tag's '>'.
+                match lower[close_start..].find('>') {
+                    Some(gt) => pos = close_start + gt + 1,
+                    None => return out, // unterminated — drop the rest
+                }
+            }
+            None => return out, // unterminated block — drop the rest
+        }
+    }
+    out.push_str(&html[pos..]);
+    out
+}
+
+fn decode_entities(text: &str) -> String {
+    text.replace("&nbsp;", " ")
+        .replace("&amp;", "&")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&quot;", "\"")
+        .replace("&#39;", "'")
+        .replace("&#x27;", "'")
+        .replace("&mdash;", "—")
+        .replace("&ndash;", "–")
+        .replace("&hellip;", "…")
+}
+
+/// Collapse runs of spaces/tabs and limit blank lines to one in a row.
+fn collapse_whitespace(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut blank_lines = 0;
+    for line in text.lines() {
+        let squeezed: String = line.split_whitespace().collect::<Vec<_>>().join(" ");
+        if squeezed.is_empty() {
+            blank_lines += 1;
+            if blank_lines <= 1 && !out.is_empty() {
+                out.push('\n');
+            }
+        } else {
+            blank_lines = 0;
+            out.push_str(&squeezed);
+            out.push('\n');
+        }
+    }
+    out.trim().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn gate_defaults_off_and_toggles() {
+        // Fresh process state: disabled until explicitly enabled.
+        assert!(!is_enabled());
+        set_enabled(true);
+        assert!(is_enabled());
+        set_enabled(false);
+        assert!(!is_enabled());
+    }
+
+    #[test]
+    fn validate_url_requires_https() {
+        assert!(validate_url("http://example.com").is_err());
+        assert!(validate_url("ftp://example.com").is_err());
+        assert!(validate_url("file:///etc/passwd").is_err());
+        assert!(validate_url("example.com").is_err());
+        assert_eq!(validate_url("https://example.com/a?b=c").unwrap(), "example.com");
+        assert_eq!(validate_url("https://Example.COM:8443/x").unwrap(), "example.com");
+    }
+
+    #[test]
+    fn validate_url_blocks_private_hosts() {
+        for bad in [
+            "https://localhost/admin",
+            "https://localhost:11434/api/tags",
+            "https://127.0.0.1/",
+            "https://10.0.0.5/router",
+            "https://192.168.1.1/",
+            "https://172.16.0.1/",
+            "https://172.31.255.255/",
+            "https://169.254.1.1/",
+            "https://printer.local/",
+            "https://[::1]/",
+            "https://user:pass@example.com/",
+        ] {
+            assert!(validate_url(bad).is_err(), "should reject {bad}");
+        }
+        // 172.32.x is public; 172.15.x is public.
+        assert!(validate_url("https://172.32.0.1/").is_ok());
+        assert!(validate_url("https://172.15.0.1/").is_ok());
+    }
+
+    #[test]
+    fn html_to_text_strips_scripts_styles_and_tags() {
+        let html = r#"<html><head><title>T &amp; U</title>
+            <style>body { color: red; }</style>
+            <SCRIPT>var secret = "nope";</SCRIPT></head>
+            <body><h1>Header</h1><p>First &quot;para&quot;.</p>
+            <div>Second<br>line</div></body></html>"#;
+        let text = html_to_text(html);
+        assert!(!text.contains("color: red"));
+        assert!(!text.contains("secret"));
+        assert!(text.contains("Header"));
+        assert!(text.contains("First \"para\"."));
+        assert!(text.contains("Second\nline"));
+    }
+
+    #[test]
+    fn html_to_text_survives_unterminated_script() {
+        let html = "<p>visible</p><script>var x = 1;"; // no closing tag
+        let text = html_to_text(html);
+        assert!(text.contains("visible"));
+        assert!(!text.contains("var x"));
+    }
+
+    #[test]
+    fn html_to_text_keeps_byte_offsets_aligned_on_unicode() {
+        // 'İ' lowercases to two chars under full Unicode rules — the ASCII-only
+        // lowering must keep strip_element's indices aligned with the original.
+        let html = "<p>İstanbul — café</p><script>var hidden = 1;</script><p>done</p>";
+        let text = html_to_text(html);
+        assert!(text.contains("İstanbul — café"));
+        assert!(text.contains("done"));
+        assert!(!text.contains("hidden"));
+    }
+
+    #[test]
+    fn extract_title_handles_attributes_and_entities() {
+        assert_eq!(
+            extract_title(r#"<title lang="en">Qwen 3.8 &mdash; notes</title>"#).unwrap(),
+            "Qwen 3.8 — notes"
+        );
+        assert!(extract_title("<body>no title</body>").is_none());
+    }
+
+    #[test]
+    fn collapse_whitespace_limits_blank_runs() {
+        let messy = "a   b\n\n\n\n c\t\td\n";
+        assert_eq!(collapse_whitespace(messy), "a b\n\nc d");
+    }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -96,6 +96,7 @@ function App() {
           voiceInputEnabled: parsed.voiceInputEnabled ?? DEFAULT_SETTINGS.voiceInputEnabled,
           voiceOutputEnabled: parsed.voiceOutputEnabled ?? DEFAULT_SETTINGS.voiceOutputEnabled,
           emailSummaryEnabled: parsed.emailSummaryEnabled ?? DEFAULT_SETTINGS.emailSummaryEnabled,
+          webResearchEnabled: parsed.webResearchEnabled ?? DEFAULT_SETTINGS.webResearchEnabled,
           calendarEnabled: parsed.calendarEnabled ?? DEFAULT_SETTINGS.calendarEnabled,
           financeEnabled: parsed.financeEnabled ?? DEFAULT_SETTINGS.financeEnabled,
           defaultView: parsed.defaultView ?? DEFAULT_SETTINGS.defaultView,
@@ -117,6 +118,15 @@ function App() {
     // Apply theme change immediately
     document.documentElement.setAttribute("data-theme", newSettings.theme);
   }, []);
+
+  // ── Web Research gate sync ──
+  // The Rust-side gate always boots OFF (offline by default); re-apply the
+  // persisted Settings choice on launch and whenever the toggle changes.
+  useEffect(() => {
+    invoke("set_web_research_enabled", { enabled: settings.webResearchEnabled }).catch(() => {
+      /* backend not ready yet — the gate simply stays off */
+    });
+  }, [settings.webResearchEnabled]);
 
   const loadAgents = useCallback(async (activeAgent?: string | null) => {
     try {

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -931,6 +931,35 @@ export default function SettingsPanel({
           </>)}
         </div>
 
+        {/* ── Web Research ── */}
+        <div className="settings-group">
+          <h3 className="settings-group-toggle" onClick={() => toggleSection("webresearch")}>
+            🌐 Web Research
+            <span className={`settings-group-chevron${expandedSections.has("webresearch") ? " settings-group-chevron--open" : ""}`}>▸</span>
+          </h3>
+          {expandedSections.has("webresearch") && (<>
+          <div className="settings-item">
+            <label>Allow Web Research (fetch links you name)</label>
+            <div className="settings-theme-toggle">
+              <button
+                className={`settings-theme-btn ${settings.webResearchEnabled ? "active" : ""}`}
+                onClick={() => update("webResearchEnabled", !settings.webResearchEnabled)}
+              >
+                {settings.webResearchEnabled ? "✅ Enabled" : "Off"}
+              </button>
+            </div>
+          </div>
+          <div className="settings-hint">
+            When enabled, chat requests like <em>"research the latest from https://… and conclude"</em> fetch
+            <strong> only the URLs you explicitly name</strong> — HTTPS-only, no search engine, no background
+            traffic, and local/private addresses are always refused. Pages are reduced to text locally and
+            synthesized by your local model. <strong>Off by default:</strong> leave it off and PrismOS stays
+            fully offline. Tip: the zero-network alternative is <em>"read my screen and conclude"</em> with the
+            page open — local vision only.
+          </div>
+          </>)}
+        </div>
+
         {/* ── Calendar Integration ── */}
         <div className="settings-group">
           <h3 className="settings-group-toggle" onClick={() => toggleSection("calendar")}>

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -4,6 +4,7 @@ import { useState, useRef, useEffect, useCallback } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import type { AppSettings, Message, RefractiveResult, RefractionAlternative, CollaborationSummary, DebateSummary, IntentTransparency, ReviewRequest } from "../types";
 import { detectDocRequest, detectFileRequest, generateDocument, generateTextFile } from "../lib/docGen";
+import { detectResearchRequest, runWebResearch, MAX_RESEARCH_URLS } from "../lib/research";
 import { detectReviewRequest, formatReportMarkdown, type ReviewReportPayload } from "../lib/projectReview";
 
 interface UseChatOptions {
@@ -362,6 +363,102 @@ export function useChat({
           };
           setMessages((prev) => [...prev, aiMsg]);
           onIntentProcessed(aiMsg.agent);
+          await refreshSuggestions(input, aiMsg.id);
+          return;
+        }
+
+        // ── Research path — explore live data and conclude ──
+        // Screen lane: zero network, local vision reads whatever is open.
+        // Web lane: opt-in (Settings + Rust gate), fetches only named URLs.
+        const research = detectResearchRequest(input);
+        if (research) {
+          if (research.mode === "screen") {
+            setProcessingPhase("Reading your screen…");
+            const resultJson = await invoke<string>("read_screen", {
+              prompt: `${input}\n\nAfter describing the relevant on-screen information, end with a clear conclusion.`,
+              ollamaUrl: settings.ollamaUrl || null,
+            });
+            const result: { context: string; model: string; auto_routed: boolean } =
+              JSON.parse(resultJson);
+            const aiMsg: Message = {
+              id: crypto.randomUUID(),
+              role: "ai",
+              content: `${result.context}\n\n───\n🖥️ Screen Research · ${result.model} · 100% local`,
+              timestamp: new Date(),
+              agent: "Screen Reader",
+            };
+            setMessages((prev) => [...prev, aiMsg]);
+            onIntentProcessed("Screen Reader");
+            await refreshSuggestions(input, aiMsg.id);
+            return;
+          }
+
+          // Web lane. Off by default — PrismOS stays offline unless opted in.
+          if (!settings.webResearchEnabled) {
+            const offMsg: Message = {
+              id: crypto.randomUUID(),
+              role: "ai",
+              content: [
+                "🌐 Web Research is **off** — PrismOS ships fully offline by default.",
+                "",
+                "Two ways to get live info:",
+                "1. **Zero network:** open the page on your screen and ask me to *\"read my screen and conclude\"* — local vision only, nothing leaves your machine.",
+                `2. **Opt in:** enable Settings → 🌐 Web Research, then re-send this with up to ${MAX_RESEARCH_URLS} links. HTTPS-only, and I fetch *only* the URLs you name — no search engine, no background traffic.`,
+              ].join("\n"),
+              timestamp: new Date(),
+              agent: "Web Researcher",
+            };
+            setMessages((prev) => [...prev, offMsg]);
+            onIntentProcessed("Web Researcher");
+            return;
+          }
+          if (research.urls.length === 0) {
+            const askMsg: Message = {
+              id: crypto.randomUUID(),
+              role: "ai",
+              content: [
+                `Web Research is on, but I need the addresses — I don't use a search engine (that would send your query to a third party). Paste up to ${MAX_RESEARCH_URLS} links, e.g.:`,
+                "",
+                "`research the latest from https://ollama.com/library/qwen3.8 and conclude`",
+                "",
+                "Or open the page and ask me to *\"read my screen\"* — that lane uses zero network.",
+              ].join("\n"),
+              timestamp: new Date(),
+              agent: "Web Researcher",
+            };
+            setMessages((prev) => [...prev, askMsg]);
+            onIntentProcessed("Web Researcher");
+            return;
+          }
+
+          setProcessingPhase("Checking Ollama connection…");
+          const ollamaOk = await invoke<boolean>("check_ollama_status", { ollamaUrl: settings.ollamaUrl || null });
+          if (!ollamaOk) {
+            throw new Error("Ollama is not running. Please start Ollama first: ollama serve");
+          }
+
+          const result = await runWebResearch(input, research.urls, {
+            model: settings.defaultModel || "mistral",
+            ollamaUrl: settings.ollamaUrl || null,
+            maxTokens: settings.maxTokens || 4096,
+            onPhase: setProcessingPhase,
+          });
+
+          const sourceLines = result.pages
+            .map((p, i) => `[${i + 1}] ${p.title} — ${p.url}`)
+            .join("\n");
+          const failNote = result.failures.length
+            ? `\n⚠️ Could not fetch: ${result.failures.join("; ")}`
+            : "";
+          const aiMsg: Message = {
+            id: crypto.randomUUID(),
+            role: "ai",
+            content: `${result.answer}\n\n───\n🌐 Web Research (opt-in) · fetched only the ${result.pages.length} link${result.pages.length > 1 ? "s" : ""} you gave\n${sourceLines}${failNote}`,
+            timestamp: new Date(),
+            agent: "Web Researcher",
+          };
+          setMessages((prev) => [...prev, aiMsg]);
+          onIntentProcessed("Web Researcher");
           await refreshSuggestions(input, aiMsg.id);
           return;
         }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -58,6 +58,7 @@ export const DEFAULT_SETTINGS = {
   voiceInputEnabled: false,
   voiceOutputEnabled: false,
   emailSummaryEnabled: false,
+  webResearchEnabled: false,
   calendarEnabled: false,
   financeEnabled: false,
   defaultView: "chat",

--- a/src/lib/research.ts
+++ b/src/lib/research.ts
@@ -57,11 +57,26 @@ export function extractUrls(input: string): string[] {
   return urls.slice(0, MAX_RESEARCH_URLS);
 }
 
-/** Screen phrasing: "read my screen and conclude", "what I'm looking at"… */
+/** Screen phrasing — requires EXPLICIT intent to inspect on-screen content.
+ *  Merely mentioning the screen ("explain why my screen is flickering") must
+ *  never trigger a capture: the verb has to target the screen itself, or the
+ *  request has to be about what is ON the screen. */
 function looksLikeScreenRequest(t: string): boolean {
+  // "read/scan/analyze/describe… my screen", "screen share"
+  if (
+    /\b(read|scan|capture|look\s+at|analy[sz]e|summari[sz]e|describe|see|watch)\b[^.?!\n]{0,30}\b(my|the|this)\s+screen\b/.test(t) ||
+    /\bscreen\s?share\b/.test(t)
+  ) {
+    return true;
+  }
+  // "what's on my screen", "what am I looking at"
+  if (/\bwhat(?:'s|\s+is)?\s+(?:on\s+(?:my|the)\s+screen|i'?\s?a?m\s+looking\s+at)\b/.test(t)) {
+    return true;
+  }
+  // "research/gather/conclude … on/from my screen" — content sourced FROM the screen
   return (
-    /\b(my|the|this)\s+screen\b|\bon\s+screen\b|\bwhat\s+i'?\s?a?m\s+looking\s+at\b|\bscreen\s?share\b/.test(t) &&
-    /\b(read|research|analy[sz]e|summari[sz]e|check|look|gather|explore|explain|conclude|describe|review|tell)\b/.test(t)
+    /\b(?:on|from)\s+(?:my|the)\s+screen\b/.test(t) &&
+    /\b(read|research|analy[sz]e|summari[sz]e|gather|explore|conclude|describe|review)\b/.test(t)
   );
 }
 

--- a/src/lib/research.ts
+++ b/src/lib/research.ts
@@ -1,0 +1,185 @@
+// research — Explore live data and conclude, two ways:
+//
+//   • screen lane — zero network. Reuses Phase-7 Contextual Screen Awareness:
+//     the user opens anything on their own screen and the local vision model
+//     reads it. Always available.
+//   • web lane — real HTTPS fetching of URLs the user explicitly names.
+//     OFF by default; double-gated (Settings toggle + a Rust-side gate that
+//     hard-refuses fetches), https-only, public hosts only, no search engine.
+//
+// The fetched pages are synthesized by the local model into a cited answer
+// that ends with an explicit conclusion.
+
+import { invoke } from "@tauri-apps/api/core";
+
+export type ResearchMode = "web" | "screen";
+
+export interface ResearchRequest {
+  mode: ResearchMode;
+  urls: string[];
+}
+
+export interface FetchedPage {
+  url: string;
+  title: string;
+  text: string;
+  truncated: boolean;
+}
+
+export interface ResearchResult {
+  answer: string;
+  pages: FetchedPage[];
+  failures: string[];
+}
+
+/** Most URLs one request will fetch — keeps prompts inside local context. */
+export const MAX_RESEARCH_URLS = 3;
+
+/** Per-source excerpt cap inside the synthesis prompt (~2k tokens each). */
+const PER_SOURCE_CHARS = 8000;
+
+/** Synthesis needs room for citations + a conclusion. */
+const MIN_SYNTHESIS_TOKENS = 4096;
+
+/** Pull https/http URLs out of a message: deduped, trailing punctuation
+ *  stripped, http upgraded to https (the backend is https-only), capped. */
+export function extractUrls(input: string): string[] {
+  const matches = input.match(/https?:\/\/[^\s<>"')\]]+/gi) ?? [];
+  const seen = new Set<string>();
+  const urls: string[] = [];
+  for (const raw of matches) {
+    const cleaned = raw.replace(/[.,;:!?]+$/, "").replace(/^http:\/\//i, "https://");
+    if (!seen.has(cleaned)) {
+      seen.add(cleaned);
+      urls.push(cleaned);
+    }
+  }
+  return urls.slice(0, MAX_RESEARCH_URLS);
+}
+
+/** Screen phrasing: "read my screen and conclude", "what I'm looking at"… */
+function looksLikeScreenRequest(t: string): boolean {
+  return (
+    /\b(my|the|this)\s+screen\b|\bon\s+screen\b|\bwhat\s+i'?\s?a?m\s+looking\s+at\b|\bscreen\s?share\b/.test(t) &&
+    /\b(read|research|analy[sz]e|summari[sz]e|check|look|gather|explore|explain|conclude|describe|review|tell)\b/.test(t)
+  );
+}
+
+/** Explicit go-online phrasing (an offline-first app must never guess here). */
+function looksLikeWebRequest(t: string): boolean {
+  return (
+    /\b(from|on|via|using|off|search(?:ing)?|browse|browsing)\s+the\s+(internet|web)\b/.test(t) ||
+    /\b(search|browse|research|look\s*up|find|gather|get|fetch|pull|check|explore)\b[^.?!\n]{0,60}\bonline\b/.test(t) ||
+    /\bonline\b[^.?!\n]{0,60}\b(search|research|info|information|sources?|news)\b/.test(t) ||
+    /\b(latest|updated|current|up[\s-]?to[\s-]?date|recent|live)\b[^.?!\n]{0,60}\b(internet|web|online|news)\b/.test(t) ||
+    /\b(internet|web|online)\b[^.?!\n]{0,60}\b(latest|updated|current|up[\s-]?to[\s-]?date|recent|info|information|data|news)\b/.test(t)
+  );
+}
+
+/**
+ * Detect a research request. Screen phrasing wins (it is the zero-network
+ * lane); otherwise explicit web phrasing, or pasted links in a short message.
+ * A long paste containing a URL (e.g. an error log that happens to mention
+ * https://ollama.com) is NOT treated as a fetch request.
+ */
+export function detectResearchRequest(input: string): ResearchRequest | null {
+  const t = input.toLowerCase().trim();
+  if (!t) return null;
+
+  if (looksLikeScreenRequest(t)) {
+    return { mode: "screen", urls: [] };
+  }
+
+  const urls = extractUrls(input);
+  if (looksLikeWebRequest(t)) {
+    return { mode: "web", urls };
+  }
+  if (urls.length > 0) {
+    // Short message with a link → the link is the point. Long messages (e.g.
+    // a pasted error log that happens to contain a URL) need an unambiguous
+    // fetch verb — generic words like "what"/"check" appear in every paste.
+    const short = input.trim().length <= 220;
+    const strongFetchVerb = /\b(fetch|visit|browse|crawl|scrape)\b/.test(t);
+    if (short || strongFetchVerb) {
+      return { mode: "web", urls };
+    }
+  }
+  return null;
+}
+
+/** Build the local-model prompt that synthesizes fetched sources into a
+ *  cited answer with an explicit conclusion. */
+export function synthesisPrompt(question: string, pages: FetchedPage[]): string {
+  const sources = pages
+    .map((p, i) => {
+      const excerpt =
+        p.text.length > PER_SOURCE_CHARS ? `${p.text.slice(0, PER_SOURCE_CHARS)}…` : p.text;
+      return `[${i + 1}] ${p.title} — ${p.url}\n${excerpt}`;
+    })
+    .join("\n\n");
+  return [
+    "You are a careful research analyst. Answer the user's request using ONLY the fetched web sources below.",
+    "",
+    `User request: "${question}"`,
+    "",
+    "Fetched sources:",
+    sources,
+    "",
+    "Rules:",
+    "- Base every claim on the sources and cite them inline like [1] or [2].",
+    "- If sources disagree, say so explicitly.",
+    "- If the sources do not contain the answer, say what is missing — do not invent facts.",
+    '- End with a short paragraph starting exactly with "Conclusion:" giving your bottom line.',
+  ].join("\n");
+}
+
+interface ResearchOptions {
+  model: string;
+  ollamaUrl?: string | null;
+  maxTokens?: number;
+  onPhase?: (phase: string) => void;
+}
+
+function shortHost(url: string): string {
+  const m = url.match(/^https:\/\/([^/]+)/i);
+  return m ? m[1] : url;
+}
+
+/**
+ * Web-lane research end-to-end: fetch each user-named URL through the gated
+ * Rust command, then synthesize a cited, concluded answer with the local model.
+ */
+export async function runWebResearch(
+  question: string,
+  urls: string[],
+  opts: ResearchOptions,
+): Promise<ResearchResult> {
+  const pages: FetchedPage[] = [];
+  const failures: string[] = [];
+
+  for (const url of urls.slice(0, MAX_RESEARCH_URLS)) {
+    opts.onPhase?.(`Fetching ${shortHost(url)}…`);
+    try {
+      const pageJson = await invoke<string>("research_fetch_url", { url });
+      pages.push(JSON.parse(pageJson) as FetchedPage);
+    } catch (e) {
+      failures.push(`${url} — ${String(e)}`);
+    }
+  }
+
+  if (pages.length === 0) {
+    throw new Error(
+      `None of the links could be fetched:\n${failures.map((f) => `• ${f}`).join("\n")}`,
+    );
+  }
+
+  opts.onPhase?.(`Synthesizing across ${pages.length} source${pages.length > 1 ? "s" : ""}…`);
+  const answer = await invoke<string>("query_ollama", {
+    prompt: synthesisPrompt(question, pages),
+    model: opts.model,
+    ollamaUrl: opts.ollamaUrl ?? null,
+    maxTokens: Math.max(opts.maxTokens ?? 0, MIN_SYNTHESIS_TOKENS),
+  });
+
+  return { answer, pages, failures };
+}

--- a/src/test/MainView.test.tsx
+++ b/src/test/MainView.test.tsx
@@ -85,6 +85,7 @@ const defaultSettings: AppSettings = {
   voiceInputEnabled: false,
   voiceOutputEnabled: false,
   emailSummaryEnabled: false,
+  webResearchEnabled: false,
   calendarEnabled: false,
   financeEnabled: false,
   defaultView: "chat",

--- a/src/test/OnboardingWizard.test.tsx
+++ b/src/test/OnboardingWizard.test.tsx
@@ -15,6 +15,7 @@ const defaultSettings: AppSettings = {
   voiceInputEnabled: false,
   voiceOutputEnabled: false,
   emailSummaryEnabled: false,
+  webResearchEnabled: false,
   calendarEnabled: false,
   financeEnabled: false,
   defaultView: "chat",

--- a/src/test/research.test.ts
+++ b/src/test/research.test.ts
@@ -78,6 +78,19 @@ describe("detectResearchRequest — screen lane", () => {
   it("does not fire without a research-ish verb", () => {
     expect(detectResearchRequest("my screen is flickering")).toBeNull();
   });
+
+  it("does NOT capture the screen for support questions that merely mention it", () => {
+    // Regression (Codex review): "explain" + "my screen" used to satisfy the
+    // old two-regex AND and silently trigger a screenshot.
+    expect(detectResearchRequest("explain why my screen is flickering")).toBeNull();
+    expect(detectResearchRequest("check why my screen keeps going black")).toBeNull();
+    expect(detectResearchRequest("tell me how to clean my screen")).toBeNull();
+  });
+
+  it("still fires on explicit inspect-intent phrasings", () => {
+    expect(detectResearchRequest("look at my screen and explain the error")?.mode).toBe("screen");
+    expect(detectResearchRequest("gather the info from my screen and conclude")?.mode).toBe("screen");
+  });
 });
 
 describe("extractUrls", () => {

--- a/src/test/research.test.ts
+++ b/src/test/research.test.ts
@@ -1,0 +1,119 @@
+// research unit tests — detection (web vs screen vs none), URL extraction,
+// and the synthesis prompt contract.
+//
+// The stakes: PrismOS is offline-first. Web-lane detection must fire ONLY on
+// explicit go-online intent or pasted links — never on ordinary chat, error
+// pastes that happen to contain a URL, or local-file requests.
+
+import { describe, it, expect } from "vitest";
+import {
+  detectResearchRequest,
+  extractUrls,
+  synthesisPrompt,
+  MAX_RESEARCH_URLS,
+  type FetchedPage,
+} from "../lib/research";
+
+describe("detectResearchRequest — web lane", () => {
+  it("fires on explicit go-online phrasing", () => {
+    expect(detectResearchRequest("gather the latest info from the internet about qwen3.8")?.mode).toBe("web");
+    expect(detectResearchRequest("research this online and conclude")?.mode).toBe("web");
+    expect(detectResearchRequest("look up the current news on the web")?.mode).toBe("web");
+    expect(detectResearchRequest("search the web for updated ollama benchmarks")?.mode).toBe("web");
+  });
+
+  it("fires when the user pastes links with an ask", () => {
+    const r = detectResearchRequest("summarize https://ollama.com/library/qwen3.8 and conclude");
+    expect(r?.mode).toBe("web");
+    expect(r?.urls).toEqual(["https://ollama.com/library/qwen3.8"]);
+  });
+
+  it("fires on a short bare-link message", () => {
+    const r = detectResearchRequest("https://example.com/article");
+    expect(r?.mode).toBe("web");
+    expect(r?.urls).toEqual(["https://example.com/article"]);
+  });
+
+  it("does NOT fire on a long error paste that merely contains a URL", () => {
+    const errorPaste = [
+      "I ran the installer and got this output, not sure what to do with it —",
+      "Error: couldn't pull model manifest: 412:",
+      "The model you are attempting to pull requires a newer version of Ollama.",
+      "Please download the latest version at: https://ollama.com/download",
+      "then it exited with code 1 after retrying twice and printing the same thing again",
+    ].join("\n");
+    expect(detectResearchRequest(errorPaste)).toBeNull();
+  });
+
+  it("still fires on a LONG message when a strong fetch verb names the link", () => {
+    const long =
+      "please fetch https://example.com/article and then walk through every claim it makes, " +
+      "compare each one against what we discussed earlier about local model licensing today, " +
+      "and finish with a clear conclusion on whether the article's take actually holds up";
+    expect(detectResearchRequest(long)?.mode).toBe("web");
+  });
+
+  it("does NOT fire on ordinary offline chat", () => {
+    expect(detectResearchRequest("research transformers")).toBeNull();
+    expect(detectResearchRequest("what is the internet")).toBeNull();
+    expect(detectResearchRequest("search my documents for the report")).toBeNull();
+    expect(detectResearchRequest("explain how websites work")).toBeNull();
+    expect(detectResearchRequest("what's the latest in the file I uploaded")).toBeNull();
+  });
+});
+
+describe("detectResearchRequest — screen lane", () => {
+  it("fires on screen phrasings", () => {
+    expect(detectResearchRequest("read my screen and conclude")?.mode).toBe("screen");
+    expect(detectResearchRequest("research what's on my screen")?.mode).toBe("screen");
+    expect(detectResearchRequest("summarize what I'm looking at")?.mode).toBe("screen");
+  });
+
+  it("screen wins over web wording when both appear", () => {
+    expect(
+      detectResearchRequest("read my screen and gather the latest info from the internet")?.mode,
+    ).toBe("screen");
+  });
+
+  it("does not fire without a research-ish verb", () => {
+    expect(detectResearchRequest("my screen is flickering")).toBeNull();
+  });
+});
+
+describe("extractUrls", () => {
+  it("dedupes, strips trailing punctuation, and upgrades http", () => {
+    expect(
+      extractUrls("see (https://a.com/x). and http://a.com/x, plus https://b.com/y?z=1"),
+    ).toEqual(["https://a.com/x", "https://b.com/y?z=1"]);
+  });
+
+  it(`caps at ${MAX_RESEARCH_URLS}`, () => {
+    const many = ["https://a.com", "https://b.com", "https://c.com", "https://d.com"].join(" ");
+    expect(extractUrls(many)).toHaveLength(MAX_RESEARCH_URLS);
+  });
+});
+
+describe("synthesisPrompt", () => {
+  const page = (over: Partial<FetchedPage> = {}): FetchedPage => ({
+    url: "https://a.com/x",
+    title: "Title A",
+    text: "Body text about qwen.",
+    truncated: false,
+    ...over,
+  });
+
+  it("numbers sources and demands a cited conclusion", () => {
+    const p = synthesisPrompt("what changed in qwen3.8?", [page(), page({ url: "https://b.com", title: "B" })]);
+    expect(p).toContain('[1] Title A — https://a.com/x');
+    expect(p).toContain('[2] B — https://b.com');
+    expect(p).toContain('"Conclusion:"');
+    expect(p).toContain("what changed in qwen3.8?");
+  });
+
+  it("truncates oversized source text", () => {
+    const big = page({ text: "x".repeat(50_000) });
+    const p = synthesisPrompt("q", [big]);
+    expect(p.length).toBeLessThan(20_000);
+    expect(p).toContain("…");
+  });
+});

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -289,6 +289,7 @@ export interface AppSettings {
   voiceInputEnabled: boolean;
   voiceOutputEnabled: boolean;
   emailSummaryEnabled: boolean;
+  webResearchEnabled: boolean;
   calendarEnabled: boolean;
   financeEnabled: boolean;
   defaultView: string;


### PR DESCRIPTION
## Description

Adds the ability to **explore live data and conclude** — two lanes, both honest about the offline invariant:

- **Screen lane (zero network, always available):** "read my screen and conclude" reuses Phase-7 Contextual Screen Awareness — local vision reads whatever page the user has open and ends with an explicit conclusion.
- **Web lane (OFF by default, opt-in):** "research the latest from https://… and conclude" fetches **only the URLs the user explicitly names** (max 3), reduces them to text locally, and synthesizes a cited answer that ends with `Conclusion:`.

### Web-lane gating (the important part)

- **Rust-side hard gate:** `web_research.rs` holds a process-wide `AtomicBool` that **boots false on every launch**; `research_fetch_url` refuses while disabled. The frontend toggle re-applies the persisted setting via `set_web_research_enabled` (synced from `App.tsx` on launch + on change).
- **HTTPS-only, public hosts only:** plain http, `localhost`, RFC-1918 / link-local / `.local`, IPv6 loopback & ULA, and credential-embedded URLs are all refused — and the **post-redirect URL is re-validated**, so a public link can't bounce the fetch onto the LAN or the Ollama port.
- **No search engine, no background use, no telemetry.** Fetches are user-named URLs only, size-capped (2 MB stream cap, 40k chars text), timeout-bounded, and **audit-logged**.
- **README disclosure** updated: Web Research joins Email Keeper as the only two opt-in features that can talk beyond localhost — leave both off (the default) and nothing opens a socket.

### Detection is deliberately conservative

Web mode fires only on explicit go-online phrasing ("from the internet", "search the web", "online") or pasted links in a short/verb-explicit message. A long error paste that merely contains a URL does **not** trigger fetching (regression-tested). Screen phrasing wins over web phrasing. Plain "research transformers" stays in normal offline chat.

### Settings

New **🌐 Web Research** group in Settings (mirrors the Email Keeper pattern): off by default, with an honest hint describing exactly what it does and the zero-network alternative.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 📚 Documentation update

## Testing

- `npx tsc --noEmit` clean
- `npx vitest run`: **212/212** (13 new tests in `src/test/research.test.ts`: web/screen/none detection incl. the error-paste negative, URL extraction/dedupe/cap/http-upgrade, synthesis-prompt contract)
- Rust: 8 new `#[cfg(test)]` unit tests in `web_research.rs` (gate default-off, https-only, private-host blocking incl. 172.16–31 boundary, HTML→text script/style stripping, unterminated-tag safety, Unicode byte-offset alignment, title extraction, whitespace collapse) — gated by the CI Backend job
- No new Rust dependencies (hand-rolled HTML→text; reqwest already present)

## Checklist

- [x] Follows the offline-first invariant: default behavior is byte-for-byte unchanged; the only new network path is double-gated and user-directed
- [x] All existing tests pass; new behavior covered by new tests