### PR TITLE
Research v2: parallel fetching, bounded link exploration, browser-open lane, graph learning

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,13 @@ Two honest caveats, because "100% offline" gets thrown around too loosely:
   you explicitly type into chat, over HTTPS, with localhost/LAN addresses
   refused. It is off by default, double-gated (a Settings toggle plus a
   Rust-side gate that hard-refuses fetches while disabled), uses no search
-  engine, and sends nothing in the background. The zero-network alternative is
-  built in: open the page and ask PrismOS to *read your screen* — local vision
-  only.
+  engine, and sends nothing in the background. Fetches run in parallel, and
+  saying *"explore"* additionally follows the most relevant links found on the
+  pages you named — bounded, and every followed link passes the same gates.
+  What it reads is indexed into the local knowledge graph so later answers can
+  retrieve it; that indexing is local SQLite, not telemetry. The zero-network
+  alternative is built in: open the page and ask PrismOS to *read your
+  screen* — local vision only.
 
 Email Keeper and Web Research are the only two features that can talk to
 anything beyond localhost. Leave both off — the default — and the app has no

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -481,6 +481,40 @@ async fn research_fetch_url(app: tauri::AppHandle, url: String) -> Result<String
     serde_json::to_string(&page).map_err(|e| e.to_string())
 }
 
+/// open_url_in_browser — Open a user-named https:// URL in the system's
+/// default browser (the "open and explore" lane). The app itself makes NO
+/// network request here — the browser does — so this works even with Web
+/// Research disabled. The same public-host validation applies: no localhost,
+/// no LAN addresses. Audit-logged.
+#[tauri::command]
+async fn open_url_in_browser(app: tauri::AppHandle, url: String) -> Result<String, String> {
+    let host = web_research::validate_url(&url)?;
+
+    #[cfg(target_os = "macos")]
+    let (cmd, args): (&str, Vec<String>) = ("open", vec![url.clone()]);
+
+    #[cfg(target_os = "windows")]
+    let (cmd, args): (&str, Vec<String>) = (
+        "cmd",
+        vec!["/C".to_string(), "start".to_string(), "".to_string(), url.clone()],
+    );
+
+    #[cfg(all(unix, not(target_os = "macos")))]
+    let (cmd, args): (&str, Vec<String>) = ("xdg-open", vec![url.clone()]);
+
+    std::process::Command::new(cmd)
+        .args(&args)
+        .spawn()
+        .map_err(|e| format!("Failed to open browser: {e}"))?;
+
+    if let Ok(app_dir) = app.path().app_data_dir() {
+        let audit = audit_log::AuditLog::new(&app_dir);
+        let _ = audit.append("open_url_in_browser", "user", &url);
+    }
+
+    Ok(host)
+}
+
 /// open_generated_file — Open a generated file (or reveal its folder) with the
 /// OS default handler. Only allows opening files that actually exist on disk.
 #[tauri::command]
@@ -3244,6 +3278,7 @@ pub fn run() {
             // Web Research — opt-in, user-directed HTTPS fetching
             set_web_research_enabled,
             research_fetch_url,
+            open_url_in_browser,
             // Project Review — gated, read-only whole-project review
             scan_project_for_review,
             run_project_review,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -493,10 +493,13 @@ async fn open_url_in_browser(app: tauri::AppHandle, url: String) -> Result<Strin
     #[cfg(target_os = "macos")]
     let (cmd, args): (&str, Vec<String>) = ("open", vec![url.clone()]);
 
+    // Shell-free on Windows: cmd.exe would interpret metacharacters like `&`
+    // in the URL as command separators (Codex finding). rundll32's
+    // FileProtocolHandler opens the default browser without any shell parsing.
     #[cfg(target_os = "windows")]
     let (cmd, args): (&str, Vec<String>) = (
-        "cmd",
-        vec!["/C".to_string(), "start".to_string(), "".to_string(), url.clone()],
+        "rundll32",
+        vec!["url.dll,FileProtocolHandler".to_string(), url.clone()],
     );
 
     #[cfg(all(unix, not(target_os = "macos")))]

--- a/src-tauri/src/web_research.rs
+++ b/src-tauri/src/web_research.rs
@@ -279,56 +279,26 @@ pub async fn fetch_url_as_text(url: &str) -> Result<FetchedPage, String> {
     })
 }
 
-/// Origin ("https://host[:port]") of an https URL.
-fn url_origin(url: &str) -> Option<String> {
-    let rest = url.trim().strip_prefix("https://")?;
-    let authority = rest.split(['/', '?', '#']).next()?;
-    if authority.is_empty() {
-        None
-    } else {
-        Some(format!("https://{authority}"))
-    }
-}
-
-/// Directory base of a URL (through the last '/') for resolving relative hrefs.
-fn url_dir(url: &str) -> String {
-    let no_q = url.split(['?', '#']).next().unwrap_or(url);
-    match no_q.rfind('/') {
-        Some(i) if i >= "https://".len() => no_q[..=i].to_string(),
-        _ => format!("{}/", no_q.trim_end_matches('/')),
-    }
-}
-
-/// Resolve an href against its page URL. Returns None for fragments,
-/// non-web schemes, and anything that fails the https/public-host checks.
+/// Resolve an href against its page URL with real RFC 3986 reference
+/// semantics (the url crate that ships with reqwest) — "next" on
+/// ".../articles/current" is a SIBLING, "?page=2" keeps the current path.
+/// Returns None for fragments, non-web schemes, and anything that fails the
+/// https/public-host checks; http:// upgrades (the backend is https-only).
 fn absolutize(href: &str, base_url: &str) -> Option<String> {
     let h = href.trim();
-    if h.is_empty() {
+    if h.is_empty() || h.starts_with('#') {
         return None;
     }
-    let hl = ascii_lower(h);
-    if hl.starts_with('#')
-        || hl.starts_with("mailto:")
-        || hl.starts_with("javascript:")
-        || hl.starts_with("tel:")
-        || hl.starts_with("data:")
-    {
-        return None;
+    let base = reqwest::Url::parse(base_url).ok()?;
+    let mut joined = base.join(h).ok()?;
+    if joined.scheme() == "http" {
+        joined.set_scheme("https").ok()?;
     }
-    let abs = if hl.starts_with("https://") {
-        h.to_string()
-    } else if hl.starts_with("http://") {
-        format!("https://{}", &h[7..]) // upgrade — the backend is https-only
-    } else if h.starts_with("//") {
-        format!("https:{h}")
-    } else if h.starts_with('/') {
-        format!("{}{}", url_origin(base_url)?, h)
-    } else if h.split('/').next().unwrap_or("").contains(':') {
-        return None; // some other scheme (ftp:, chrome:, …)
-    } else {
-        format!("{}{}", url_dir(base_url), h)
-    };
-    let abs = abs.split('#').next().unwrap_or(&abs).to_string();
+    if joined.scheme() != "https" {
+        return None; // mailto:, javascript:, tel:, data:, ftp:, …
+    }
+    joined.set_fragment(None);
+    let abs = joined.to_string();
     validate_url(&abs).ok()?;
     Some(abs)
 }
@@ -591,7 +561,9 @@ mod tests {
 
     #[test]
     fn extract_links_absolutizes_filters_and_dedupes() {
-        let html = r#"<a href="/docs">Docs</a>
+        // NOTE the r##…## delimiter: the HTML contains `"#` (href="#section"),
+        // which would terminate a single-# raw string.
+        let html = r##"<a href="/docs">Docs</a>
             <a href="page2.html">Next <span>page</span></a>
             <a href="https://other.example.org/deep">Other</a>
             <a href="http://insecure.example.com/x">Upgraded</a>
@@ -600,7 +572,7 @@ mod tests {
             <a href="mailto:a@b.c">Mail</a>
             <a href="javascript:void(0)">JS</a>
             <a href="https://192.168.1.1/router">LAN</a>
-            <a href="/docs">Dup</a>"#;
+            <a href="/docs">Dup</a>"##;
         let links = extract_links(html, "https://example.com/blog/post.html");
         let urls: Vec<&str> = links.iter().map(|l| l.url.as_str()).collect();
         assert!(urls.contains(&"https://example.com/docs"));
@@ -614,6 +586,27 @@ mod tests {
     }
 
     #[test]
+    fn absolutize_follows_rfc3986_reference_semantics() {
+        // Codex regression: relative refs resolve against the full URL, not a
+        // naive directory concatenation.
+        assert_eq!(
+            absolutize("next", "https://example.com/articles/current").unwrap(),
+            "https://example.com/articles/next"
+        );
+        assert_eq!(
+            absolutize("?page=2", "https://example.com/articles/current").unwrap(),
+            "https://example.com/articles/current?page=2"
+        );
+        assert_eq!(
+            absolutize("../up", "https://example.com/a/b/c").unwrap(),
+            "https://example.com/a/up"
+        );
+        assert!(absolutize("#frag", "https://example.com/x").is_none());
+        assert!(absolutize("mailto:a@b.c", "https://example.com/x").is_none());
+        assert!(absolutize("javascript:void(0)", "https://example.com/x").is_none());
+    }
+
+    #[test]
     fn extract_links_caps_output_and_skips_a_lookalike_tags() {
         let mut html = String::from("<article><p>no links here</p></article>");
         for i in 0..40 {
@@ -621,13 +614,6 @@ mod tests {
         }
         let links = extract_links(&html, "https://x.example.com/");
         assert_eq!(links.len(), 30);
-    }
-
-    #[test]
-    fn url_dir_and_origin_resolve_correctly() {
-        assert_eq!(url_dir("https://a.com/x/y.html"), "https://a.com/x/");
-        assert_eq!(url_dir("https://a.com"), "https://a.com/");
-        assert_eq!(url_origin("https://a.com:8443/x/y").unwrap(), "https://a.com:8443");
     }
 
     #[test]

--- a/src-tauri/src/web_research.rs
+++ b/src-tauri/src/web_research.rs
@@ -33,6 +33,11 @@ const MAX_REDIRECTS: usize = 5;
 const MAX_FETCH_BYTES: usize = 2 * 1024 * 1024;
 /// Cap on the extracted plain text handed back over IPC.
 const MAX_TEXT_CHARS: usize = 40_000;
+/// Most in-page links reported per fetched page (the frontend ranks and
+/// follows at most a handful; this just bounds the IPC payload).
+const MAX_LINKS: usize = 30;
+/// Anchor-text cap per reported link.
+const MAX_ANCHOR_CHARS: usize = 120;
 
 pub fn set_enabled(enabled: bool) {
     WEB_RESEARCH_ENABLED.store(enabled, Ordering::SeqCst);
@@ -48,6 +53,15 @@ pub struct FetchedPage {
     pub title: String,
     pub text: String,
     pub truncated: bool,
+    /// In-page links (absolute https, public hosts only) so the frontend can
+    /// EXPLORE: rank them against the question and follow the best few.
+    pub links: Vec<LinkOut>,
+}
+
+#[derive(Serialize)]
+pub struct LinkOut {
+    pub url: String,
+    pub text: String,
 }
 
 /// Validate that a URL is https and points at a public host.
@@ -254,13 +268,128 @@ pub async fn fetch_url_as_text(url: &str) -> Result<FetchedPage, String> {
     if text.trim().is_empty() {
         return Err("The page had no readable text (it may be script-rendered or non-HTML).".to_string());
     }
+    let links = extract_links(&body, &final_url);
 
     Ok(FetchedPage {
         url: final_url,
         title,
         text,
         truncated,
+        links,
     })
+}
+
+/// Origin ("https://host[:port]") of an https URL.
+fn url_origin(url: &str) -> Option<String> {
+    let rest = url.trim().strip_prefix("https://")?;
+    let authority = rest.split(['/', '?', '#']).next()?;
+    if authority.is_empty() {
+        None
+    } else {
+        Some(format!("https://{authority}"))
+    }
+}
+
+/// Directory base of a URL (through the last '/') for resolving relative hrefs.
+fn url_dir(url: &str) -> String {
+    let no_q = url.split(['?', '#']).next().unwrap_or(url);
+    match no_q.rfind('/') {
+        Some(i) if i >= "https://".len() => no_q[..=i].to_string(),
+        _ => format!("{}/", no_q.trim_end_matches('/')),
+    }
+}
+
+/// Resolve an href against its page URL. Returns None for fragments,
+/// non-web schemes, and anything that fails the https/public-host checks.
+fn absolutize(href: &str, base_url: &str) -> Option<String> {
+    let h = href.trim();
+    if h.is_empty() {
+        return None;
+    }
+    let hl = ascii_lower(h);
+    if hl.starts_with('#')
+        || hl.starts_with("mailto:")
+        || hl.starts_with("javascript:")
+        || hl.starts_with("tel:")
+        || hl.starts_with("data:")
+    {
+        return None;
+    }
+    let abs = if hl.starts_with("https://") {
+        h.to_string()
+    } else if hl.starts_with("http://") {
+        format!("https://{}", &h[7..]) // upgrade — the backend is https-only
+    } else if h.starts_with("//") {
+        format!("https:{h}")
+    } else if h.starts_with('/') {
+        format!("{}{}", url_origin(base_url)?, h)
+    } else if h.split('/').next().unwrap_or("").contains(':') {
+        return None; // some other scheme (ftp:, chrome:, …)
+    } else {
+        format!("{}{}", url_dir(base_url), h)
+    };
+    let abs = abs.split('#').next().unwrap_or(&abs).to_string();
+    validate_url(&abs).ok()?;
+    Some(abs)
+}
+
+/// Pull `<a href>` links (with anchor text) out of a page. Everything is
+/// absolutized against the page URL and passed through the same https/public
+/// validation as user-named URLs — a page can never steer exploration onto
+/// localhost or the LAN. Deduped and capped.
+pub fn extract_links(html: &str, base_url: &str) -> Vec<LinkOut> {
+    let lower = ascii_lower(html);
+    let mut out: Vec<LinkOut> = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+    let mut pos = 0;
+    while let Some(rel) = lower[pos..].find("<a") {
+        let tag_start = pos + rel;
+        // Require "<a" + whitespace/'>' so <article>/<abbr> don't match.
+        let after = lower.as_bytes().get(tag_start + 2).copied();
+        if !matches!(after, Some(b' ') | Some(b'\t') | Some(b'\n') | Some(b'\r') | Some(b'>')) {
+            pos = tag_start + 2;
+            continue;
+        }
+        let tag_end = match lower[tag_start..].find('>') {
+            Some(i) => tag_start + i,
+            None => break,
+        };
+        let tag = &html[tag_start..tag_end];
+        let tag_l = &lower[tag_start..tag_end];
+        let href = tag_l.find("href").and_then(|hi| {
+            let rest = &tag[hi + 4..];
+            let eq = rest.find('=')?;
+            let v = rest[eq + 1..].trim_start();
+            let (quote, v2) = match v.chars().next()? {
+                '"' => ('"', &v[1..]),
+                '\'' => ('\'', &v[1..]),
+                _ => (' ', v),
+            };
+            let end = if quote == ' ' {
+                v2.find(|c: char| c.is_whitespace() || c == '>').unwrap_or(v2.len())
+            } else {
+                v2.find(quote)?
+            };
+            Some(v2[..end].to_string())
+        });
+        let close = lower[tag_end..].find("</a").map(|i| tag_end + i);
+        let text = close
+            .map(|c| html_to_text(&html[tag_end + 1..c]).replace('\n', " "))
+            .unwrap_or_default();
+        pos = close.unwrap_or(tag_end) + 1;
+        if let Some(hraw) = href {
+            if let Some(abs) = absolutize(&hraw, base_url) {
+                if seen.insert(abs.clone()) {
+                    let t: String = text.chars().take(MAX_ANCHOR_CHARS).collect();
+                    out.push(LinkOut { url: abs, text: t });
+                    if out.len() >= MAX_LINKS {
+                        break;
+                    }
+                }
+            }
+        }
+    }
+    out
 }
 
 /// ASCII-only lowercase that preserves byte offsets exactly (Unicode
@@ -458,6 +587,47 @@ mod tests {
         assert_eq!(url_port("https://example.com:8443/x"), 8443);
         assert_eq!(url_port("https://[2606:4700::1111]/x"), 443);
         assert_eq!(url_port("https://[2606:4700::1111]:9443/x"), 9443);
+    }
+
+    #[test]
+    fn extract_links_absolutizes_filters_and_dedupes() {
+        let html = r#"<a href="/docs">Docs</a>
+            <a href="page2.html">Next <span>page</span></a>
+            <a href="https://other.example.org/deep">Other</a>
+            <a href="http://insecure.example.com/x">Upgraded</a>
+            <a href="//cdn.example.com/lib">Protocol-relative</a>
+            <a href="#section">Frag</a>
+            <a href="mailto:a@b.c">Mail</a>
+            <a href="javascript:void(0)">JS</a>
+            <a href="https://192.168.1.1/router">LAN</a>
+            <a href="/docs">Dup</a>"#;
+        let links = extract_links(html, "https://example.com/blog/post.html");
+        let urls: Vec<&str> = links.iter().map(|l| l.url.as_str()).collect();
+        assert!(urls.contains(&"https://example.com/docs"));
+        assert!(urls.contains(&"https://example.com/blog/page2.html"));
+        assert!(urls.contains(&"https://other.example.org/deep"));
+        assert!(urls.contains(&"https://insecure.example.com/x"));
+        assert!(urls.contains(&"https://cdn.example.com/lib"));
+        assert_eq!(links.len(), 5, "frag/mailto/js/LAN/dup must be dropped: {urls:?}");
+        let next = links.iter().find(|l| l.url.ends_with("page2.html")).unwrap();
+        assert_eq!(next.text, "Next page");
+    }
+
+    #[test]
+    fn extract_links_caps_output_and_skips_a_lookalike_tags() {
+        let mut html = String::from("<article><p>no links here</p></article>");
+        for i in 0..40 {
+            html.push_str(&format!("<a href=\"https://x.example.com/p{i}\">L{i}</a>"));
+        }
+        let links = extract_links(&html, "https://x.example.com/");
+        assert_eq!(links.len(), 30);
+    }
+
+    #[test]
+    fn url_dir_and_origin_resolve_correctly() {
+        assert_eq!(url_dir("https://a.com/x/y.html"), "https://a.com/x/");
+        assert_eq!(url_dir("https://a.com"), "https://a.com/");
+        assert_eq!(url_origin("https://a.com:8443/x/y").unwrap(), "https://a.com:8443");
     }
 
     #[test]

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -952,10 +952,12 @@ export default function SettingsPanel({
           <div className="settings-hint">
             When enabled, chat requests like <em>"research the latest from https://… and conclude"</em> fetch
             <strong> only the URLs you explicitly name</strong> — HTTPS-only, no search engine, no background
-            traffic, and local/private addresses are always refused. Pages are reduced to text locally and
-            synthesized by your local model. <strong>Off by default:</strong> leave it off and PrismOS stays
-            fully offline. Tip: the zero-network alternative is <em>"read my screen and conclude"</em> with the
-            page open — local vision only.
+            traffic, and local/private addresses are always refused. Pages download <strong>in parallel</strong>;
+            add <em>"explore"</em> and the most relevant links found on those pages are followed too (bounded,
+            same protections). Everything read is <strong>indexed into your local Spectrum Graph</strong> so
+            future answers can retrieve it — knowledge updates, model weights never change, nothing phones home.
+            <strong> Off by default:</strong> leave it off and PrismOS stays fully offline. Tip: the zero-network
+            alternative is <em>"read my screen and conclude"</em> with the page open — local vision only.
           </div>
           </>)}
         </div>

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -372,6 +372,25 @@ export function useChat({
         // Web lane: opt-in (Settings + Rust gate), fetches only named URLs.
         const research = detectResearchRequest(input);
         if (research) {
+          // Open lane — pop the page in the user's real browser (the app
+          // makes no network request; works even with Web Research off).
+          if (research.mode === "open") {
+            setProcessingPhase("Opening in your browser…");
+            const host = await invoke<string>("open_url_in_browser", {
+              url: research.urls[0],
+            });
+            const aiMsg: Message = {
+              id: crypto.randomUUID(),
+              role: "ai",
+              content: `🌐 Opened **${host}** in your default browser. Once the page loads, say *"read my screen and conclude"* — zero network, and it works on script-heavy pages that plain fetching can't parse.`,
+              timestamp: new Date(),
+              agent: "Web Researcher",
+            };
+            setMessages((prev) => [...prev, aiMsg]);
+            onIntentProcessed("Web Researcher");
+            return;
+          }
+
           if (research.mode === "screen") {
             setProcessingPhase("Reading your screen…");
             const resultJson = await invoke<string>("read_screen", {
@@ -421,6 +440,8 @@ export function useChat({
                 "",
                 "`research the latest from https://ollama.com/library/qwen3.8 and conclude`",
                 "",
+                "Add **\"explore\"** and I'll also follow the most relevant links found on those pages (in parallel, same protections). Everything I read gets indexed into your Spectrum Graph for future answers.",
+                "",
                 "Or open the page and ask me to *\"read my screen\"* — that lane uses zero network.",
               ].join("\n"),
               timestamp: new Date(),
@@ -441,6 +462,7 @@ export function useChat({
             model: settings.defaultModel || "mistral",
             ollamaUrl: settings.ollamaUrl || null,
             maxTokens: settings.maxTokens || 4096,
+            explore: research.explore,
             onPhase: setProcessingPhase,
           });
 
@@ -450,10 +472,16 @@ export function useChat({
           const failNote = result.failures.length
             ? `\n⚠️ Could not fetch: ${result.failures.join("; ")}`
             : "";
+          const exploredNote = result.explored
+            ? ` (${result.explored} discovered by exploring links on your pages)`
+            : "";
+          const learnedNote = result.learnedChunks
+            ? `\n🧠 Learned ${result.learnedChunks} chunk${result.learnedChunks > 1 ? "s" : ""} into your Spectrum Graph — future answers can draw on this.`
+            : "";
           const aiMsg: Message = {
             id: crypto.randomUUID(),
             role: "ai",
-            content: `${result.answer}\n\n───\n🌐 Web Research (opt-in) · fetched only the ${result.pages.length} link${result.pages.length > 1 ? "s" : ""} you gave\n${sourceLines}${failNote}`,
+            content: `${result.answer}\n\n───\n🌐 Web Research (opt-in) · ${result.pages.length} source${result.pages.length > 1 ? "s" : ""} fetched in parallel${exploredNote}\n${sourceLines}${failNote}${learnedNote}`,
             timestamp: new Date(),
             agent: "Web Researcher",
           };

--- a/src/lib/research.ts
+++ b/src/lib/research.ts
@@ -12,11 +12,18 @@
 
 import { invoke } from "@tauri-apps/api/core";
 
-export type ResearchMode = "web" | "screen";
+export type ResearchMode = "web" | "screen" | "open";
 
 export interface ResearchRequest {
   mode: ResearchMode;
   urls: string[];
+  /** Follow the best links found on the seed pages (second parallel wave). */
+  explore: boolean;
+}
+
+export interface PageLink {
+  url: string;
+  text: string;
 }
 
 export interface FetchedPage {
@@ -24,19 +31,34 @@ export interface FetchedPage {
   title: string;
   text: string;
   truncated: boolean;
+  links: PageLink[];
 }
 
 export interface ResearchResult {
   answer: string;
   pages: FetchedPage[];
   failures: string[];
+  /** Pages fetched by following links discovered on the seed pages. */
+  explored: number;
+  /** Chunks indexed into the Spectrum Graph for future retrieval. */
+  learnedChunks: number;
 }
 
-/** Most URLs one request will fetch — keeps prompts inside local context. */
+/** Most user-named seed URLs per request. */
 export const MAX_RESEARCH_URLS = 3;
+
+/** Most discovered links followed in the explore wave. */
+export const MAX_EXPLORE_LINKS = 4;
+
+/** Hard ceiling on pages per research run (seeds + explored). */
+const TOTAL_PAGE_CAP = 7;
 
 /** Per-source excerpt cap inside the synthesis prompt (~2k tokens each). */
 const PER_SOURCE_CHARS = 8000;
+
+/** Total source-text budget across ALL pages — keeps the synthesis prompt
+ *  inside the local model's context window even at 7 sources. */
+const TOTAL_PROMPT_CHARS = 24000;
 
 /** Synthesis needs room for citations + a conclusion. */
 const MIN_SYNTHESIS_TOKENS = 4096;
@@ -97,17 +119,34 @@ function looksLikeWebRequest(t: string): boolean {
  * A long paste containing a URL (e.g. an error log that happens to mention
  * https://ollama.com) is NOT treated as a fetch request.
  */
+/** "explore / dig deeper / thorough / multithreaded" → follow the best links
+ *  discovered on the seed pages in a second parallel wave. */
+function wantsExplore(t: string): boolean {
+  return /\b(explore|exploring|deep|deeper|deep[\s-]?dive|thorough|thoroughly|dig\s+(?:in|into|deeper)|comprehensive|comprehensively|multi[\s-]?threaded)\b/.test(t);
+}
+
 export function detectResearchRequest(input: string): ResearchRequest | null {
   const t = input.toLowerCase().trim();
   if (!t) return null;
 
   if (looksLikeScreenRequest(t)) {
-    return { mode: "screen", urls: [] };
+    return { mode: "screen", urls: [], explore: false };
   }
 
   const urls = extractUrls(input);
+  const explore = wantsExplore(t);
+
+  // Open lane: "open https://… (in browser)" → pop it in the real browser.
+  if (
+    urls.length > 0 &&
+    (/^\s*(?:please\s+)?open\s+https?:\/\//i.test(input) ||
+      (/\bopen\b/.test(t) && /\bin\s+(?:my\s+|the\s+|a\s+)?browser\b/.test(t)))
+  ) {
+    return { mode: "open", urls, explore: false };
+  }
+
   if (looksLikeWebRequest(t)) {
-    return { mode: "web", urls };
+    return { mode: "web", urls, explore };
   }
   if (urls.length > 0) {
     // Short message with a link → the link is the point. Long messages (e.g.
@@ -116,19 +155,64 @@ export function detectResearchRequest(input: string): ResearchRequest | null {
     const short = input.trim().length <= 220;
     const strongFetchVerb = /\b(fetch|visit|browse|crawl|scrape)\b/.test(t);
     if (short || strongFetchVerb) {
-      return { mode: "web", urls };
+      return { mode: "web", urls, explore };
     }
   }
   return null;
 }
 
+/** Rank links discovered on fetched pages by keyword overlap with the
+ *  question; already-fetched URLs are excluded. Exported for tests. */
+export function rankLinks(
+  question: string,
+  pages: FetchedPage[],
+  max: number = MAX_EXPLORE_LINKS,
+): PageLink[] {
+  const stop = new Set([
+    "this", "that", "with", "from", "about", "what", "when", "where", "which",
+    "have", "will", "your", "then", "them", "these", "those", "please",
+    "https", "http", "conclude", "research", "explore", "latest", "info",
+    "information", "internet", "online",
+  ]);
+  const kws = new Set(
+    question
+      .toLowerCase()
+      .split(/[^a-z0-9.]+/)
+      .filter((w) => w.length >= 4 && !stop.has(w)),
+  );
+  const norm = (u: string) => u.replace(/\/+$/, "").toLowerCase();
+  const seen = new Set(pages.map((p) => norm(p.url)));
+  const scored: { link: PageLink; score: number; order: number }[] = [];
+  let order = 0;
+  for (const p of pages) {
+    for (const l of p.links ?? []) {
+      const key = norm(l.url);
+      if (seen.has(key)) continue;
+      seen.add(key);
+      const hay = `${l.text} ${l.url}`.toLowerCase();
+      let score = 0;
+      for (const k of kws) {
+        if (hay.includes(k)) score++;
+      }
+      if (score > 0) scored.push({ link: l, score, order: order++ });
+    }
+  }
+  scored.sort((a, b) => b.score - a.score || a.order - b.order);
+  return scored.slice(0, max).map((s) => s.link);
+}
+
 /** Build the local-model prompt that synthesizes fetched sources into a
  *  cited answer with an explicit conclusion. */
 export function synthesisPrompt(question: string, pages: FetchedPage[]): string {
+  // Scale the per-source excerpt so the whole prompt stays inside the local
+  // model's context window even when the explore wave adds pages.
+  const per = Math.min(
+    PER_SOURCE_CHARS,
+    Math.max(2000, Math.floor(TOTAL_PROMPT_CHARS / Math.max(1, pages.length))),
+  );
   const sources = pages
     .map((p, i) => {
-      const excerpt =
-        p.text.length > PER_SOURCE_CHARS ? `${p.text.slice(0, PER_SOURCE_CHARS)}…` : p.text;
+      const excerpt = p.text.length > per ? `${p.text.slice(0, per)}…` : p.text;
       return `[${i + 1}] ${p.title} — ${p.url}\n${excerpt}`;
     })
     .join("\n\n");
@@ -152,33 +236,67 @@ interface ResearchOptions {
   model: string;
   ollamaUrl?: string | null;
   maxTokens?: number;
+  /** Follow the best discovered links in a second parallel wave. */
+  explore?: boolean;
   onPhase?: (phase: string) => void;
 }
 
-function shortHost(url: string): string {
-  const m = url.match(/^https:\/\/([^/]+)/i);
-  return m ? m[1] : url;
+/** One gated fetch; failures become data instead of exceptions so a bad link
+ *  never sinks the whole parallel wave. */
+async function fetchOne(url: string): Promise<{ page?: FetchedPage; failure?: string }> {
+  try {
+    const pageJson = await invoke<string>("research_fetch_url", { url });
+    return { page: JSON.parse(pageJson) as FetchedPage };
+  } catch (e) {
+    return { failure: `${url} — ${String(e)}` };
+  }
 }
 
 /**
- * Web-lane research end-to-end: fetch each user-named URL through the gated
- * Rust command, then synthesize a cited, concluded answer with the local model.
+ * Web-lane research end-to-end:
+ *   1. fetch the user-named seeds IN PARALLEL (each invoke runs on the Rust
+ *      tokio thread pool, so downloads genuinely overlap),
+ *   2. optionally EXPLORE — rank the links found on those pages against the
+ *      question and fetch the best few, also in parallel,
+ *   3. synthesize a cited answer that ends with a conclusion,
+ *   4. LEARN — index every fetched page into the Spectrum Graph so future
+ *      questions can retrieve this data (the local, honest version of
+ *      "keeping the model up to date": weights never change, knowledge does).
  */
 export async function runWebResearch(
   question: string,
   urls: string[],
   opts: ResearchOptions,
 ): Promise<ResearchResult> {
+  const seeds = urls.slice(0, MAX_RESEARCH_URLS);
+  opts.onPhase?.(
+    `Fetching ${seeds.length} page${seeds.length > 1 ? "s in parallel" : ""}…`,
+  );
+  const wave1 = await Promise.all(seeds.map((u) => fetchOne(u)));
   const pages: FetchedPage[] = [];
   const failures: string[] = [];
+  for (const r of wave1) {
+    if (r.page) pages.push(r.page);
+    else if (r.failure) failures.push(r.failure);
+  }
 
-  for (const url of urls.slice(0, MAX_RESEARCH_URLS)) {
-    opts.onPhase?.(`Fetching ${shortHost(url)}…`);
-    try {
-      const pageJson = await invoke<string>("research_fetch_url", { url });
-      pages.push(JSON.parse(pageJson) as FetchedPage);
-    } catch (e) {
-      failures.push(`${url} — ${String(e)}`);
+  let explored = 0;
+  if (opts.explore && pages.length > 0) {
+    const followCap = Math.min(MAX_EXPLORE_LINKS, TOTAL_PAGE_CAP - pages.length);
+    const follow = followCap > 0 ? rankLinks(question, pages, followCap) : [];
+    if (follow.length > 0) {
+      opts.onPhase?.(
+        `Exploring ${follow.length} linked page${follow.length > 1 ? "s in parallel" : ""}…`,
+      );
+      const wave2 = await Promise.all(follow.map((l) => fetchOne(l.url)));
+      for (const r of wave2) {
+        if (r.page) {
+          pages.push(r.page);
+          explored++;
+        } else if (r.failure) {
+          failures.push(r.failure);
+        }
+      }
     }
   }
 
@@ -196,5 +314,23 @@ export async function runWebResearch(
     maxTokens: Math.max(opts.maxTokens ?? 0, MIN_SYNTHESIS_TOKENS),
   });
 
-  return { answer, pages, failures };
+  // Learn: chunk + index each page into the Spectrum Graph (best-effort —
+  // a graph hiccup must never lose the answer). Sequential on purpose: the
+  // graph sits behind a mutex, so parallel calls would only contend.
+  let learnedChunks = 0;
+  opts.onPhase?.("Indexing sources into the Spectrum Graph…");
+  for (const p of pages) {
+    try {
+      const idsJson = await invoke<string>("index_document_chunks", {
+        text: p.text,
+        source: p.url,
+      });
+      const ids = JSON.parse(idsJson);
+      if (Array.isArray(ids)) learnedChunks += ids.length;
+    } catch {
+      /* learning is best-effort */
+    }
+  }
+
+  return { answer, pages, failures, explored, learnedChunks };
 }

--- a/src/test/research.test.ts
+++ b/src/test/research.test.ts
@@ -9,8 +9,10 @@ import { describe, it, expect } from "vitest";
 import {
   detectResearchRequest,
   extractUrls,
+  rankLinks,
   synthesisPrompt,
   MAX_RESEARCH_URLS,
+  MAX_EXPLORE_LINKS,
   type FetchedPage,
 } from "../lib/research";
 
@@ -93,6 +95,70 @@ describe("detectResearchRequest — screen lane", () => {
   });
 });
 
+describe("detectResearchRequest — open lane + explore flag", () => {
+  it("routes 'open <url>' to the browser-open lane", () => {
+    expect(detectResearchRequest("open https://example.com/docs")?.mode).toBe("open");
+    expect(detectResearchRequest("please open https://example.com in my browser")?.mode).toBe("open");
+  });
+
+  it("does not hijack open-requests without a URL", () => {
+    expect(detectResearchRequest("open the csv file")).toBeNull();
+  });
+
+  it("plain summarize-a-link stays in the web lane", () => {
+    expect(detectResearchRequest("summarize https://example.com/a and conclude")?.mode).toBe("web");
+  });
+
+  it("sets explore on 'explore'/'dig deeper'/'multithreaded' phrasings", () => {
+    expect(detectResearchRequest("research https://a.com/x and explore deeper")?.explore).toBe(true);
+    expect(detectResearchRequest("dig into https://a.com/x thoroughly")?.explore).toBe(true);
+    expect(detectResearchRequest("multithreaded research on https://a.com/x")?.explore).toBe(true);
+    expect(detectResearchRequest("summarize https://a.com/x and conclude")?.explore).toBe(false);
+  });
+});
+
+describe("rankLinks", () => {
+  const page = (url: string, links: { url: string; text: string }[]): FetchedPage => ({
+    url,
+    title: "T",
+    text: "body",
+    truncated: false,
+    links,
+  });
+
+  it("ranks by keyword overlap with the question and skips fetched URLs", () => {
+    const pages = [
+      page("https://a.com/qwen", [
+        { url: "https://a.com/qwen/benchmarks", text: "Qwen benchmark results" },
+        { url: "https://a.com/about", text: "About us" },
+        { url: "https://a.com/qwen", text: "Self link (already fetched)" },
+        { url: "https://a.com/qwen/quantization", text: "Quantization notes for qwen" },
+      ]),
+    ];
+    const ranked = rankLinks("qwen benchmark quantization results", pages);
+    expect(ranked.map((l) => l.url)).toEqual([
+      "https://a.com/qwen/benchmarks",
+      "https://a.com/qwen/quantization",
+    ]);
+  });
+
+  it(`caps at ${MAX_EXPLORE_LINKS} and dedupes across pages`, () => {
+    const links = Array.from({ length: 10 }, (_, i) => ({
+      url: `https://a.com/qwen/${i}`,
+      text: `qwen article ${i}`,
+    }));
+    const pages = [page("https://a.com/1", links), page("https://a.com/2", links)];
+    const ranked = rankLinks("qwen article", pages);
+    expect(ranked).toHaveLength(MAX_EXPLORE_LINKS);
+    expect(new Set(ranked.map((l) => l.url)).size).toBe(MAX_EXPLORE_LINKS);
+  });
+
+  it("returns nothing when no link relates to the question", () => {
+    const pages = [page("https://a.com/x", [{ url: "https://a.com/careers", text: "Careers" }])];
+    expect(rankLinks("qwen quantization accuracy", pages)).toHaveLength(0);
+  });
+});
+
 describe("extractUrls", () => {
   it("dedupes, strips trailing punctuation, and upgrades http", () => {
     expect(
@@ -112,6 +178,7 @@ describe("synthesisPrompt", () => {
     title: "Title A",
     text: "Body text about qwen.",
     truncated: false,
+    links: [],
     ...over,
   });
 
@@ -128,5 +195,14 @@ describe("synthesisPrompt", () => {
     const p = synthesisPrompt("q", [big]);
     expect(p.length).toBeLessThan(20_000);
     expect(p).toContain("…");
+  });
+
+  it("scales the per-source budget so 7 sources still fit the context window", () => {
+    const pages = Array.from({ length: 7 }, (_, i) =>
+      page({ url: `https://a.com/${i}`, text: "y".repeat(20_000) }),
+    );
+    const p = synthesisPrompt("q", pages);
+    expect(p.length).toBeLessThan(30_000);
+    expect(p).toContain("[7]");
   });
 });


### PR DESCRIPTION
## Description

Builds on #22 with the three capabilities requested: **browser opening/exploration, multithreaded fetching, and learning** — each done the honest, gated way.

### 1. Explore (better data for reasoning)

- `research_fetch_url` now also returns the page's **in-page links** (`links: [{url, text}]`) — absolutized against the page URL, **passed through the exact same https/public-host validation as user-named URLs** (a page can never steer exploration onto localhost/LAN), deduped, capped at 30.
- Saying **"explore" / "dig deeper" / "thoroughly" / "multithreaded"** triggers a second wave: `rankLinks` scores discovered links by keyword overlap with the question, follows the best ≤4, hard ceiling **7 pages total** per run. Followed links appear in the sources list — nothing is fetched invisibly.
- New **open lane**: `open https://…` (or "… in my browser") pops the page in the user's real default browser via a new `open_url_in_browser` command (same validation; the app itself makes no network request, so it works with Web Research off) — then "read my screen and conclude" covers script-heavy pages.

### 2. Multithreaded fetching

Seed pages and explore-wave pages now download **in parallel** (`Promise.all` → each invoke is a task on the Rust tokio thread pool). A 3-source run drops from ~3× fetch latency to ~1×. The synthesis prompt's per-source budget scales (`min(8000, max(2000, 24000/n))`) so 7 sources still fit the local context window.

### 3. Learning (keeping knowledge — not weights — up to date)

After synthesis, every fetched page is **chunked and indexed into the Spectrum Graph** via the existing Phase-6 `index_document_chunks` (source = URL, local SQLite). Future questions retrieve it through the normal RAG path. The footer reports "🧠 Learned N chunks". Indexing is sequential by design (the graph sits behind a mutex) and best-effort (a graph hiccup never loses the answer).

### Unchanged invariants

Off by default, Rust-side gate boots false every launch, HTTPS-only, per-hop redirect validation + DNS pre-resolution/pinning, no search engine, audit-logged, README/Settings disclosure updated to describe exploration + indexing plainly.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 📚 Documentation update

## Testing

- `npx tsc --noEmit` clean
- `npx vitest run`: **222/222** (8 new: open-lane routing, explore-flag phrasings, rankLinks scoring/dedupe/cap/no-match, 7-source prompt budget)
- Rust: 3 new unit tests (extract_links absolutize/filter/dedupe incl. LAN-link rejection and anchor text, output cap + `<article>` lookalike safety, url_dir/url_origin resolution) — 15 total in the module, gated by the CI Backend job
- Still no new dependencies