### PR TITLE
fix: screen-read vision routing + honest error cards (found by live E2E)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -288,9 +288,14 @@ async fn read_screen(
         .unwrap_or_default();
     let model_names: Vec<String> = models.iter().map(|m| m.name.clone()).collect();
 
+    // No hardcoded "preferred" model here: passing a vision-named literal made
+    // the router treat it as the user's choice and skip the installed-model
+    // scan, which 404'd on every machine without that exact model installed.
+    // An empty user model forces auto-detection from what is actually there
+    // (VISION_MODEL_PRIORITY: qwen3-vl first, then qwen2.5vl, …).
     let route = smart_router::route_model(
-        "llama3.2-vision", // preferred default for screen reading
-        true,              // has_image = true
+        "",   // no user-selected model — auto-detect from installed list
+        true, // has_image = true
         false,
         false,
         &model_names,

--- a/src-tauri/src/smart_router.rs
+++ b/src-tauri/src/smart_router.rs
@@ -363,8 +363,18 @@ pub fn route_model(
 
     // ── Priority 1: Vision routing (images require a vision model) ──
     if has_image {
-        // If user already selected a vision model, use it
-        if is_vision_model(user_model) {
+        // If user already selected a vision model, use it — but only when it
+        // is actually installed. An empty `available_models` means the model
+        // list could not be fetched (Ollama briefly unreachable); stay
+        // optimistic then rather than second-guessing the user. A vision-NAMED
+        // model that is visibly absent must not be trusted: sending it to
+        // Ollama just returns `model '…' not found` (the read_screen
+        // regression this guards against).
+        let user_vision_installed = available_models.is_empty()
+            || available_models
+                .iter()
+                .any(|m| m.eq_ignore_ascii_case(user_model));
+        if is_vision_model(user_model) && user_vision_installed {
             return RoutingDecision {
                 model: user_model.to_string(),
                 auto_swapped: false,
@@ -741,5 +751,44 @@ mod tests {
         let d = route_for_task("mistral", TaskKind::Code, &models);
         assert!(!d.auto_swapped);
         assert_eq!(d.model, "mistral");
+    }
+
+    #[test]
+    fn route_model_swaps_when_named_vision_model_is_not_installed() {
+        // Regression: read_screen used to pass a hardcoded "llama3.2-vision",
+        // and the router trusted any vision-named user model without checking
+        // the installed list — a guaranteed `model not found` on every machine
+        // without that exact model.
+        let available = vec!["qwen3-vl:32b".to_string(), "qwen3.8:27b".to_string()];
+        let route = route_model("llama3.2-vision", true, false, false, &available);
+        assert_eq!(route.model, "qwen3-vl:32b");
+        assert!(route.auto_swapped);
+        assert!(route.is_vision);
+    }
+
+    #[test]
+    fn route_model_keeps_user_vision_model_when_installed() {
+        let available = vec!["qwen2.5vl:7b".to_string(), "qwen3.8:27b".to_string()];
+        let route = route_model("qwen2.5vl:7b", true, false, false, &available);
+        assert_eq!(route.model, "qwen2.5vl:7b");
+        assert!(!route.auto_swapped);
+    }
+
+    #[test]
+    fn route_model_stays_optimistic_when_model_list_is_unavailable() {
+        // Empty list = the tags fetch failed; don't second-guess the user then.
+        let available: Vec<String> = vec![];
+        let route = route_model("llama3.2-vision", true, false, false, &available);
+        assert_eq!(route.model, "llama3.2-vision");
+        assert!(!route.auto_swapped);
+    }
+
+    #[test]
+    fn route_model_with_empty_user_model_auto_detects_installed_vision() {
+        // read_screen now passes "" — always resolve from what's installed.
+        let available = vec!["qwen3.8:27b".to_string(), "qwen2.5vl:7b".to_string()];
+        let route = route_model("", true, false, false, &available);
+        assert_eq!(route.model, "qwen2.5vl:7b");
+        assert!(route.auto_swapped);
     }
 }

--- a/src-tauri/src/smart_router.rs
+++ b/src-tauri/src/smart_router.rs
@@ -141,6 +141,19 @@ pub struct ModelCapabilities {
 
 // ─── Core Routing Logic ────────────────────────────────────────────────────────
 
+/// Ollama treats a bare model name and `name:latest` as the same model —
+/// `/api/tags` reports `llava:latest` for a model the user selected as
+/// `llava`. Compare names with that alias folded away (case-insensitive).
+fn models_match(a: &str, b: &str) -> bool {
+    fn norm(s: &str) -> String {
+        let s = s.to_lowercase();
+        s.strip_suffix(":latest")
+            .map(|p| p.to_string())
+            .unwrap_or(s)
+    }
+    norm(a) == norm(b)
+}
+
 /// Check if a model name indicates vision capability
 pub fn is_vision_model(model_name: &str) -> bool {
     let lower = model_name.to_lowercase();
@@ -373,7 +386,7 @@ pub fn route_model(
         let user_vision_installed = available_models.is_empty()
             || available_models
                 .iter()
-                .any(|m| m.eq_ignore_ascii_case(user_model));
+                .any(|m| models_match(m, user_model));
         if is_vision_model(user_model) && user_vision_installed {
             return RoutingDecision {
                 model: user_model.to_string(),
@@ -781,6 +794,22 @@ mod tests {
         let route = route_model("llama3.2-vision", true, false, false, &available);
         assert_eq!(route.model, "llama3.2-vision");
         assert!(!route.auto_swapped);
+    }
+
+    #[test]
+    fn route_model_treats_implicit_latest_tag_as_installed() {
+        // Ollama reports `llava:latest` in /api/tags for a model the user
+        // selected as bare `llava` — the alias must count as installed, in
+        // both directions.
+        let available = vec!["llava:latest".to_string(), "qwen3-vl:32b".to_string()];
+        let route = route_model("llava", true, false, false, &available);
+        assert_eq!(route.model, "llava");
+        assert!(!route.auto_swapped);
+
+        let available2 = vec!["llava".to_string()];
+        let route2 = route_model("llava:latest", true, false, false, &available2);
+        assert_eq!(route2.model, "llava:latest");
+        assert!(!route2.auto_swapped);
     }
 
     #[test]

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -6,6 +6,7 @@ import type { AppSettings, Message, RefractiveResult, RefractionAlternative, Col
 import { detectDocRequest, detectFileRequest, generateDocument, generateTextFile } from "../lib/docGen";
 import { detectResearchRequest, runWebResearch, MAX_RESEARCH_URLS } from "../lib/research";
 import { detectReviewRequest, formatReportMarkdown, type ReviewReportPayload } from "../lib/projectReview";
+import { buildErrorMessage } from "../lib/errors";
 
 interface UseChatOptions {
   settings: AppSettings;
@@ -799,25 +800,7 @@ export function useChat({
   };
 }
 
-// ── Helper: build user-friendly error messages ──
-function buildErrorMessage(err: unknown, settings: AppSettings): Message {
-  const errorStr = String(err);
-  const isOllamaError = errorStr.includes("connection") || errorStr.includes("refused") || errorStr.includes("timeout") || errorStr.includes("error sending request") || errorStr.includes("fetch");
-  const isModelError = errorStr.includes("model") || errorStr.includes("not found");
-
-  let content: string;
-  if (isOllamaError) {
-    content = `⚠️ Cannot connect to Ollama.\n\nPlease ensure Ollama is running:\n  1. Install from https://ollama.com\n  2. ollama pull ${settings.defaultModel}\n  3. ollama serve\n\nIf Ollama is running, check that it's accessible at:\n  ${settings.ollamaUrl}\n\nThen try your intent again.`;
-  } else if (isModelError) {
-    content = `⚠️ Model "${settings.defaultModel}" not available.\n\nTo fix this:\n  1. ollama pull ${settings.defaultModel}\n  2. Or switch to a different model in Settings\n\nAvailable models can be listed with:\n  ollama list`;
-  } else {
-    content = `⚠️ Unable to process your intent.\n\nError: ${errorStr}\n\nTroubleshooting:\n  • Check that Ollama is running: ollama serve\n  • Verify your model is downloaded: ollama list\n  • Check Settings for the correct Ollama URL\n  • Try a simpler intent to test the connection`;
-  }
-
-  return {
-    id: crypto.randomUUID(),
-    role: "system",
-    content,
-    timestamp: new Date(),
-  };
-}
+// Error-card construction lives in src/lib/errors.ts (buildErrorMessage) so it
+// can be unit-tested without dragging in the Tauri runtime — wrong blame in an
+// error card is itself a bug class (a Screen Recording denial once rendered as
+// "model not available").

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -29,7 +29,7 @@ export function buildErrorMessage(err: unknown, settings: AppSettings): Message 
 
   let content: string;
   if (isCaptureError) {
-    content = `⚠️ Couldn't capture your screen.\n\nOn macOS this is almost always the Screen Recording permission:\n  1. System Settings → Privacy & Security → Screen Recording\n  2. Enable PrismOS-AI, then relaunch the app\n\nDetails: ${errorStr}`;
+    content = `⚠️ Couldn't capture your screen.\n\nThis is a capture-permission or display problem, not a model problem:\n  • macOS: System Settings → Privacy & Security → Screen Recording → enable PrismOS-AI, then relaunch the app\n  • Windows/Linux: check the app has screen-capture permission and a display is connected (headless sessions can't capture)\n\nDetails: ${errorStr}`;
   } else if (isOllamaError) {
     content = `⚠️ Cannot connect to Ollama.\n\nPlease ensure Ollama is running:\n  1. Install from https://ollama.com\n  2. ollama pull ${settings.defaultModel}\n  3. ollama serve\n\nIf Ollama is running, check that it's accessible at:\n  ${settings.ollamaUrl}\n\nThen try your intent again.`;
   } else if (namedModel) {

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,0 +1,49 @@
+// errors — user-facing error cards for chat failures.
+//
+// Kept as a pure module (no Tauri imports) so it is unit-testable. The rules
+// here encode one principle: blame the thing that actually failed. An Ollama
+// 404 names the exact model in its body; a screen-capture failure is a macOS
+// permission problem, not a model problem. Rendering "Model X not available"
+// for either of those sends the user chasing the wrong fix.
+
+import type { AppSettings, Message } from "../types";
+
+export function buildErrorMessage(err: unknown, settings: AppSettings): Message {
+  const errorStr = String(err);
+
+  // Screen-capture failures (read_screen lane). Checked first — they are the
+  // most specific, and on macOS the fix is a privacy toggle, not a model pull.
+  const isCaptureError =
+    errorStr.includes("Screen capture failed") ||
+    errorStr.includes("No monitor found") ||
+    errorStr.includes("Failed to enumerate monitors");
+
+  const isOllamaError = errorStr.includes("connection") || errorStr.includes("refused") || errorStr.includes("timeout") || errorStr.includes("error sending request") || errorStr.includes("fetch");
+
+  // Ollama 404s name the exact model: `model 'llama3.2-vision' not found`.
+  // Blame that model — never assume it was the user's default (auto-routing
+  // may have selected a different one).
+  const namedModel = errorStr.match(/model '([^']+)' not found/)?.[1];
+
+  const isModelError = errorStr.includes("model") || errorStr.includes("not found");
+
+  let content: string;
+  if (isCaptureError) {
+    content = `⚠️ Couldn't capture your screen.\n\nOn macOS this is almost always the Screen Recording permission:\n  1. System Settings → Privacy & Security → Screen Recording\n  2. Enable PrismOS-AI, then relaunch the app\n\nDetails: ${errorStr}`;
+  } else if (isOllamaError) {
+    content = `⚠️ Cannot connect to Ollama.\n\nPlease ensure Ollama is running:\n  1. Install from https://ollama.com\n  2. ollama pull ${settings.defaultModel}\n  3. ollama serve\n\nIf Ollama is running, check that it's accessible at:\n  ${settings.ollamaUrl}\n\nThen try your intent again.`;
+  } else if (namedModel) {
+    content = `⚠️ Model "${namedModel}" is not installed.\n\nTo fix this:\n  1. ollama pull ${namedModel}\n  2. Or switch to a different model in Settings\n\nAvailable models can be listed with:\n  ollama list`;
+  } else if (isModelError) {
+    content = `⚠️ Model "${settings.defaultModel}" not available.\n\nTo fix this:\n  1. ollama pull ${settings.defaultModel}\n  2. Or switch to a different model in Settings\n\nAvailable models can be listed with:\n  ollama list`;
+  } else {
+    content = `⚠️ Unable to process your intent.\n\nError: ${errorStr}\n\nTroubleshooting:\n  • Check that Ollama is running: ollama serve\n  • Verify your model is downloaded: ollama list\n  • Check Settings for the correct Ollama URL\n  • Try a simpler intent to test the connection`;
+  }
+
+  return {
+    id: crypto.randomUUID(),
+    role: "system",
+    content,
+    timestamp: new Date(),
+  };
+}

--- a/src/test/error-messages.test.ts
+++ b/src/test/error-messages.test.ts
@@ -1,0 +1,60 @@
+// error-messages — buildErrorMessage must blame the thing that actually failed.
+//
+// Regression suite for the E2E-found bug where a screen-read failure rendered
+// as `Model "qwen3.8:27b" not available` — the model was fine; the router had
+// requested a model that wasn't installed, and before that a macOS permission
+// denial produced the same misleading card.
+
+import { describe, it, expect } from "vitest";
+import { buildErrorMessage } from "../lib/errors";
+import type { AppSettings } from "../types";
+
+const settings = {
+  defaultModel: "qwen3.8:27b",
+  ollamaUrl: "http://localhost:11434",
+} as AppSettings;
+
+describe("buildErrorMessage", () => {
+  it("blames the exact model named in an Ollama 404, not the default", () => {
+    const msg = buildErrorMessage(
+      `Vision analysis failed: {"error":"model 'llama3.2-vision' not found"}`,
+      settings,
+    );
+    expect(msg.content).toContain('"llama3.2-vision" is not installed');
+    expect(msg.content).toContain("ollama pull llama3.2-vision");
+    expect(msg.content).not.toContain('"qwen3.8:27b" not available');
+  });
+
+  it("maps screen-capture failures to Screen Recording guidance, not a model card", () => {
+    const msg = buildErrorMessage(
+      "Screen capture failed: CGDisplayStream access denied",
+      settings,
+    );
+    expect(msg.content).toContain("Screen Recording");
+    expect(msg.content).not.toContain("not available");
+    expect(msg.content).not.toContain("ollama pull");
+  });
+
+  it("maps monitor-enumeration failures to the capture card too", () => {
+    const msg = buildErrorMessage("No monitor found for screen capture", settings);
+    expect(msg.content).toContain("Screen Recording");
+  });
+
+  it("keeps the connection card for transport errors", () => {
+    const msg = buildErrorMessage(
+      "error sending request for url (http://localhost:11434/api/generate)",
+      settings,
+    );
+    expect(msg.content).toContain("Cannot connect to Ollama");
+  });
+
+  it("falls back to the default-model card when a model error names nothing", () => {
+    const msg = buildErrorMessage("some model error without a name", settings);
+    expect(msg.content).toContain('"qwen3.8:27b" not available');
+  });
+
+  it("keeps the generic card for unrecognized errors", () => {
+    const msg = buildErrorMessage("something entirely different broke", settings);
+    expect(msg.content).toContain("Unable to process your intent");
+  });
+});


### PR DESCRIPTION
## Description
Live E2E testing of the research features (driving the built app itself) found the screen-read lane broken on this machine — and the error card blamed the wrong thing.

**Root cause (two bugs, one misleading card):**
1. `read_screen` passed a hardcoded `"llama3.2-vision"` to the router as if the user had selected it, and `route_model` trusted any vision-*named* user model without checking the installed list. Every machine without that exact model got Ollama's `model 'llama3.2-vision' not found` — instantly.
2. `buildErrorMessage` mapped any "model … not found" error to `Model "<default>" not available`, blaming the user's default model (which was fine). A macOS Screen Recording denial rendered the same misleading card.

**Fix:**
- `route_model`: a user-selected vision model is only trusted when it is actually installed. An empty model list (tags fetch failed) stays optimistic — don't second-guess the user when blind.
- `read_screen`: passes `""` — always auto-detect from the installed list (VISION_MODEL_PRIORITY: qwen3-vl → qwen2.5vl → …).
- `buildErrorMessage` moved to `src/lib/errors.ts` (pure, unit-testable): blames the exact model named in the Ollama 404, and screen-capture failures get Screen Recording guidance instead of a model card.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Testing
- `npx tsc --noEmit` clean; `npx vitest run` **228/228** (6 new error-card tests)
- 4 new Rust router regression tests (compiled + run by the CI Backend job)
- Reproduced live on macOS before the fix: instant `Model "qwen3.8:27b" not available` card on "read my screen and conclude"; direct probe `POST /api/generate {model:"llama3.2-vision"}` returns 404 `model 'llama3.2-vision' not found` while `/api/tags` lists `qwen3-vl:32b` installed.