### PR TITLE
feat(cli): add --json flag for scriptable ask/models/health

### DIFF
--- a/src-tauri/src/bin/prismos_cli.rs
+++ b/src-tauri/src/bin/prismos_cli.rs
@@ -71,7 +71,7 @@ struct GenerateChunk {
     error: Option<String>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 struct ModelEntry {
     name: String,
     #[serde(default)]
@@ -81,6 +81,20 @@ struct ModelEntry {
 #[derive(Debug, Deserialize)]
 struct ModelList {
     models: Vec<ModelEntry>,
+}
+
+// JSON output structures for --json flag
+#[derive(Debug, Serialize)]
+struct HealthJson {
+    ok: bool,
+    url: String,
+}
+
+#[derive(Debug, Serialize)]
+struct AskJson {
+    model: String,
+    response: String,
+    truncated: bool,
 }
 
 // ─── arg parsing ──────────────────────────────────────────────────────────────
@@ -94,6 +108,7 @@ struct Args {
     from_stdin: bool,
     think: Option<bool>,
     prompt: String,
+    json_output: bool,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -128,6 +143,7 @@ fn parse_args() -> Result<Args, String> {
         from_stdin: false,
         think: None,
         prompt: String::new(),
+        json_output: false,
     };
 
     let mut i = 1;
@@ -144,6 +160,7 @@ fn parse_args() -> Result<Args, String> {
             }
             "--no-stream" => args.no_stream = true,
             "--stdin"     => args.from_stdin = true,
+            "--json"      => args.json_output = true,
             "--think"     => args.think = Some(true),
             "--no-think"  => args.think = Some(false),
             "--help" | "-h" => {
@@ -183,6 +200,7 @@ impl Args {
             from_stdin: false,
             think: None,
             prompt: String::new(),
+            json_output: false,
         }
     }
 }
@@ -208,6 +226,7 @@ OPTIONS
       --stdin          Read the prompt from stdin (lets you pipe in files).
       --think          Ask a thinking-capable model for a reasoning trace.
       --no-think       Force thinking off (default for qwen3 chat models).
+      --json           Output machine-readable JSON (implies --no-stream for ask).
 
 EXAMPLES
   prismos-cli health
@@ -236,16 +255,34 @@ async fn main() -> ExitCode {
         Cmd::Help    => { print!("{HELP}"); ExitCode::SUCCESS }
         Cmd::Version => { println!("prismos-cli {}", env!("CARGO_PKG_VERSION")); ExitCode::SUCCESS }
         Cmd::Health  => match check_health(&args.base_url).await {
-            Ok(true)  => { println!("ok — ollama is up at {}", args.base_url); ExitCode::SUCCESS }
-            Ok(false) => { eprintln!("down — no response from {}", args.base_url); ExitCode::from(1) }
+            Ok(true)  => {
+                if args.json_output {
+                    let json = HealthJson { ok: true, url: args.base_url.clone() };
+                    println!("{}", serde_json::to_string(&json).unwrap());
+                } else {
+                    println!("ok — ollama is up at {}", args.base_url);
+                }
+                ExitCode::SUCCESS
+            }
+            Ok(false) => {
+                if args.json_output {
+                    let json = HealthJson { ok: false, url: args.base_url.clone() };
+                    println!("{}", serde_json::to_string(&json).unwrap());
+                } else {
+                    eprintln!("down — no response from {}", args.base_url);
+                }
+                ExitCode::from(1)
+            }
             Err(e)    => { eprintln!("error: {e}"); ExitCode::from(1) }
         },
         Cmd::Models  => match list_models(&args.base_url).await {
             Ok(models) => {
-                if models.is_empty() {
+                if args.json_output {
+                    println!("{}", serde_json::to_string(&models).unwrap());
+                } else if models.is_empty() {
                     println!("(no models pulled — try: ollama pull qwen3:4b)");
                 } else {
-                    for m in models {
+                    for m in &models {
                         println!("{:<32}  {:>10}", m.name, human_size(m.size));
                     }
                 }
@@ -261,7 +298,9 @@ async fn main() -> ExitCode {
                 );
                 return ExitCode::from(1);
             }
-            let res = if args.no_stream {
+            let res = if args.json_output {
+                generate_json(&args).await
+            } else if args.no_stream {
                 generate_blocking(&args).await
             } else {
                 generate_streaming(&args).await
@@ -423,6 +462,22 @@ async fn generate_blocking(a: &Args) -> Result<(), Box<dyn std::error::Error + S
     if parsed.done_reason.as_deref() == Some("length") {
         eprintln!("[prismos-cli] note: answer hit the token ceiling and may be incomplete");
     }
+    Ok(())
+}
+
+async fn generate_json(a: &Args) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let resp = post_generate(a, false).await?;
+    if !resp.status().is_success() {
+        return Err(format!("ollama returned {}: {}", resp.status(), resp.text().await.unwrap_or_default()).into());
+    }
+    let parsed: GenerateChunk = resp.json().await?;
+    let truncated = parsed.done_reason.as_deref() == Some("length");
+    let json = AskJson {
+        model: a.model.clone(),
+        response: strip_think(&parsed.response),
+        truncated,
+    };
+    println!("{}", serde_json::to_string(&json).unwrap());
     Ok(())
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Adds machine-readable JSON output to `prismos-cli` for scripting use cases as requested in the issue.

Closes #11

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🚀 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [ ] ♻️ Code refactor (no functional changes)
- [ ] 🎨 UI/UX improvement
- [ ] ⚡ Performance improvement

## Changes Made

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] TypeScript builds without errors (`npx tsc --noEmit`)
- [ ] Rust compiles without warnings (`cargo clippy`)

Note: The repo has no existing CLI tests, so none were added or updated. Clippy CI is tracked in #10 and not in scope for this change.

## Implementation

Added `--json` flag that enables JSON output for all three commands:

### `prismos-cli models --json`
```json
[{"name":"qwen3:4b","size":2620000000}, ...]
```

### `prismos-cli health --json`
```json
{"ok":true,"url":"http://localhost:11434"}
```

### `prismos-cli ask --json "..."`
```json
{"model":"qwen3:4b","response":"...","truncated":false}
```

The `--json` flag for `ask` implies `--no-stream` since JSON output requires collecting the full response.

### Behavior

- Errors continue to go to stderr
- JSON only goes to stdout
- Exit codes unchanged (0 for success, 1 for errors, 2 for arg parse errors)
- Help text updated to document the new flag

## Testing

```
[x] Rust compiles without errors
[x] Manual testing completed
```

Steps to test:
1. Build: `cargo build --bin prismos-cli`
2. Test health JSON (without Ollama): `./target/debug/prismos-cli health --json` → `{"ok":false,"url":"http://localhost:11434"}`
3. With Ollama running: `./target/debug/prismos-cli models --json | jq '.[0].name'` should output the first model name

## Environment

- **OS:** Linux
- **Rust version:** 1.97.1

## Additional Context

This is a self-contained change to `src-tauri/src/bin/prismos_cli.rs` only, using `serde_json` which was already available as a dependency.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b34abc3c-b616-47af-b4a2-dec798958d0d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b34abc3c-b616-47af-b4a2-dec798958d0d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

